### PR TITLE
Don't set Traceview::Config[:service_key]

### DIFF
--- a/lib/oboe_metal.rb
+++ b/lib/oboe_metal.rb
@@ -30,13 +30,13 @@ module TraceView
           when 'udp'
             options = "addr=#{TraceView::Config[:reporter_host]},port=#{TraceView::Config[:reporter_port]}"
           else
-            # ssl reporter requires the service key passed in as arg "cid"
-            if TraceView::Config[:service_key].to_s == ''
+            if ENV['TRACELYTICS_SERVICE_KEY'].to_s == ''
               TraceView.logger.warn "[traceview/warn] TRACELYTICS_SERVICE_KEY not set. Cannot submit data."
               TraceView.loaded = false
               return
             end
-            options = "cid=#{TraceView::Config[:service_key]}"
+            # ssl reporter requires the service key passed in as arg "cid"
+            options = "cid=#{ENV['TRACELYTICS_SERVICE_KEY']}"
           end
 
           TraceView.reporter = Oboe_metal::Reporter.new(protocol, options)

--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -87,9 +87,6 @@ module TraceView
       # Setup an empty host blacklist (see: TraceView::API::Util.blacklisted?)
       @@config[:blacklist] = []
 
-      # Service key is required, take default from env var
-      @@config[:service_key] = ENV['TRACELYTICS_SERVICE_KEY']
-
       # Logging of outgoing HTTP query args
       #
       # This optionally disables the logging of query args of outgoing


### PR DESCRIPTION
Instead, read TRACELYTICS_SERVICE_KEY directly and pass that to Oboe.

For #4.
