### PR TITLE
Added comments to clarify per-request xtrace logic

### DIFF
--- a/lib/traceview/api/logging.rb
+++ b/lib/traceview/api/logging.rb
@@ -120,7 +120,7 @@ module TraceView
           opts[:SampleRate]        = TraceView.sample_rate
           opts[:SampleSource]      = TraceView.sample_source
           opts[:TraceOrigin]       = :always_sampled
-          
+
           if xtrace_v2?(xtrace)
             # continue valid incoming xtrace
             # use it for current context, ensuring sample bit is set


### PR DESCRIPTION
@prettycoder I added these comments we talked about during code review, mostly because I'm going to point @bmacnaughton at it as reference when he starts on the node implementation.