### PR TITLE
Allow ENV settings through config file AO-7742

### DIFF
--- a/lib/appoptics_apm.rb
+++ b/lib/appoptics_apm.rb
@@ -24,7 +24,7 @@ begin
       require '/usr/local/tracelytics/tracelyticsagent.jar'
       require 'joboe_metal'
     elsif RUBY_PLATFORM =~ /linux/
-      require 'oboe_metal.so'
+      require_relative './oboe_metal.so'
       require 'oboe_metal.rb'  # sets AppOpticsAPM.loaded = true if successful
     else
       $stderr.puts '==================================================================='
@@ -34,10 +34,11 @@ begin
       $stderr.puts 'Contact support@appoptics.com if this is unexpected.'
       $stderr.puts '==================================================================='
     end
-  rescue LoadError
+  rescue LoadError => e
     unless ENV['RAILS_GROUP'] == 'assets' or ENV['IGNORE_APPOPTICS_WARNING']
       $stderr.puts '=============================================================='
       $stderr.puts 'Missing AppOpticsAPM libraries.  Tracing disabled.'
+      $stderr.puts "Error: #{e.message}"
       $stderr.puts 'See: https://docs.appoptics.com/kb/apm_tracing/ruby/'
       $stderr.puts '=============================================================='
     end

--- a/lib/appoptics_apm.rb
+++ b/lib/appoptics_apm.rb
@@ -18,10 +18,11 @@ begin
   # with an alternate metal (see the oboe-heroku gem)
   unless defined?(OboeHeroku)
     require 'appoptics_apm/base'
+    AppOpticsAPM.loaded = false
+
     require 'appoptics_apm/config'
     AppOpticsAPM::Config.load_config_file
 
-    AppOpticsAPM.loaded = false
     begin
       if RUBY_PLATFORM == 'java'
         require '/usr/local/tracelytics/tracelyticsagent.jar'
@@ -52,6 +53,8 @@ begin
   require 'appoptics_apm/method_profiling'
 
   if AppOpticsAPM.loaded
+    # tracing mode is configured via config file but can only be set once we have oboe_metal loaded
+    AppOpticsAPM.set_tracing_mode(AppOpticsAPM::Config[:tracing_mode].to_sym)
     require 'appoptics_apm/instrumentation'
 
     # Frameworks

--- a/lib/appoptics_apm.rb
+++ b/lib/appoptics_apm.rb
@@ -13,38 +13,33 @@ begin
   require 'appoptics_apm/util'
   require 'appoptics_apm/xtrace'
   require 'appoptics_apm/support'
+  require 'appoptics_apm/base'
+  AppOpticsAPM.loaded = false
 
-  # If OboeHeroku is already defined then we are in a PaaS environment
-  # with an alternate metal (see the oboe-heroku gem)
-  unless defined?(OboeHeroku)
-    require 'appoptics_apm/base'
-    AppOpticsAPM.loaded = false
+  require 'appoptics_apm/config'
+  AppOpticsAPM::Config.load_config_file
 
-    require 'appoptics_apm/config'
-    AppOpticsAPM::Config.load_config_file
-
-    begin
-      if RUBY_PLATFORM == 'java'
-        require '/usr/local/tracelytics/tracelyticsagent.jar'
-        require 'joboe_metal'
-      elsif RUBY_PLATFORM =~ /linux/
-        require 'oboe_metal.so'
-        require 'oboe_metal.rb'  # sets AppOpticsAPM.loaded = true  if successful
-      else
-        $stderr.puts '==================================================================='
-        $stderr.puts "AppOptics warning: Platform #{RUBY_PLATFORM} not yet supported."
-        $stderr.puts 'see: https://docs.appoptics.com/kb/apm_tracing/supported_platforms/'
-        $stderr.puts 'Tracing disabled.'
-        $stderr.puts 'Contact support@appoptics.com if this is unexpected.'
-        $stderr.puts '==================================================================='
-      end
-    rescue LoadError
-      unless ENV['RAILS_GROUP'] == 'assets' or ENV['IGNORE_APPOPTICS_WARNING']
-        $stderr.puts '=============================================================='
-        $stderr.puts 'Missing AppOpticsAPM libraries.  Tracing disabled.'
-        $stderr.puts 'See: https://docs.appoptics.com/kb/apm_tracing/ruby/'
-        $stderr.puts '=============================================================='
-      end
+  begin
+    if RUBY_PLATFORM == 'java'
+      require '/usr/local/tracelytics/tracelyticsagent.jar'
+      require 'joboe_metal'
+    elsif RUBY_PLATFORM =~ /linux/
+      require 'oboe_metal.so'
+      require 'oboe_metal.rb'  # sets AppOpticsAPM.loaded = true if successful
+    else
+      $stderr.puts '==================================================================='
+      $stderr.puts "AppOptics warning: Platform #{RUBY_PLATFORM} not yet supported."
+      $stderr.puts 'see: https://docs.appoptics.com/kb/apm_tracing/supported_platforms/'
+      $stderr.puts 'Tracing disabled.'
+      $stderr.puts 'Contact support@appoptics.com if this is unexpected.'
+      $stderr.puts '==================================================================='
+    end
+  rescue LoadError
+    unless ENV['RAILS_GROUP'] == 'assets' or ENV['IGNORE_APPOPTICS_WARNING']
+      $stderr.puts '=============================================================='
+      $stderr.puts 'Missing AppOpticsAPM libraries.  Tracing disabled.'
+      $stderr.puts 'See: https://docs.appoptics.com/kb/apm_tracing/ruby/'
+      $stderr.puts '=============================================================='
     end
   end
 

--- a/lib/appoptics_apm.rb
+++ b/lib/appoptics_apm.rb
@@ -18,8 +18,10 @@ begin
   # with an alternate metal (see the oboe-heroku gem)
   unless defined?(OboeHeroku)
     require 'appoptics_apm/base'
-    AppOpticsAPM.loaded = false
+    require 'appoptics_apm/config'
+    AppOpticsAPM::Config.load_config_file
 
+    AppOpticsAPM.loaded = false
     begin
       if RUBY_PLATFORM == 'java'
         require '/usr/local/tracelytics/tracelyticsagent.jar'
@@ -44,9 +46,6 @@ begin
       end
     end
   end
-
-  require 'appoptics_apm/config'
-  AppOpticsAPM::Config.load_config_file
 
   require 'appoptics_apm/loading'
   require 'appoptics_apm/legacy_method_profiling'

--- a/lib/appoptics_apm/sdk.rb
+++ b/lib/appoptics_apm/sdk.rb
@@ -299,7 +299,14 @@ module AppOpticsAPM
       #   end
       #
       def appoptics_ready?(wait_milliseconds = 3000)
-        AppopticsAPM::Context.isReady(wait_milliseconds)
+        # These codes are returned by isReady:
+        # OBOE_SERVER_RESPONSE_UNKNOWN 0
+        # OBOE_SERVER_RESPONSE_OK 1
+        # OBOE_SERVER_RESPONSE_TRY_LATER 2
+        # OBOE_SERVER_RESPONSE_LIMIT_EXCEEDED 3
+        # OBOE_SERVER_RESPONSE_INVALID_API_KEY 4
+        # OBOE_SERVER_RESPONSE_CONNECT_ERROR 5
+        AppopticsAPM::Context.isReady(wait_milliseconds) == 1
       end
     end
 

--- a/lib/oboe_metal.rb
+++ b/lib/oboe_metal.rb
@@ -29,13 +29,13 @@ module AppOpticsAPM
           when 'udp'
             options = "addr=#{AppOpticsAPM::Config[:reporter_host]},port=#{AppOpticsAPM::Config[:reporter_port]}"
           else
-            if ENV['APPOPTICS_SERVICE_KEY'].to_s == ''
+            if AppOpticsAPM::Config[:service_key].to_s == ''
               AppOpticsAPM.logger.warn "[appoptics_apm/warn] APPOPTICS_SERVICE_KEY not set. Cannot submit data."
               AppOpticsAPM.loaded = false
               return
             end
             # ssl reporter requires the service key passed in as arg "cid"
-            options = "cid=#{ENV['APPOPTICS_SERVICE_KEY']}"
+            options = "cid=#{AppOpticsAPM::Config[:service_key]}"
           end
 
           AppOpticsAPM.reporter = Oboe_metal::Reporter.new(protocol, options)

--- a/lib/oboe_metal.rb
+++ b/lib/oboe_metal.rb
@@ -21,24 +21,27 @@ module AppOpticsAPM
         return unless AppOpticsAPM.loaded
 
         begin
-          protocol = ENV.key?('APPOPTICS_GEM_TEST') ? 'file' : 'ssl'
+          options = []
 
-          case protocol
+          ENV['APPOPTICS_REPORTER'] = 'file' if ENV.key?('APPOPTICS_GEM_TEST')
+
+          case ENV['APPOPTICS_REPORTER']
           when 'file'
-            options = "file=#{TRACE_FILE}"
+            ENV['APPOPTICS_REPORTER_FILE'] = TRACE_FILE
           when 'udp'
-            options = "addr=#{AppOpticsAPM::Config[:reporter_host]},port=#{AppOpticsAPM::Config[:reporter_port]}"
-          else
-            if AppOpticsAPM::Config[:service_key].to_s == ''
+            ENV['APPOPTICS_REPORTER_UDP'] = "#{AppOpticsAPM::Config[:reporter_host]}:#{AppOpticsAPM::Config[:reporter_port]}"
+          else # default is ssl, service_key is mandatory
+            if AppOpticsAPM::Config[:service_key].to_s == '' && ENV['APPOPTICS_SERVICE_KEY'].to_s == ''
               AppOpticsAPM.logger.warn "[appoptics_apm/warn] APPOPTICS_SERVICE_KEY not set. Cannot submit data."
               AppOpticsAPM.loaded = false
               return
             end
-            # ssl reporter requires the service key passed in as arg "cid"
-            options = "cid=#{AppOpticsAPM::Config[:service_key]}"
+            # Oboe will override these settings if there are env settings for them
+            options << AppOpticsAPM::Config[:service_key].to_s
+            options << AppOpticsAPM::Config[:hostname_alias].to_s
+            options << AppOpticsAPM::Config[:debug_level] unless AppOpticsAPM::Config[:debug_level].nil?
           end
-
-          AppOpticsAPM.reporter = Oboe_metal::Reporter.new(protocol, options)
+          AppOpticsAPM.reporter = Oboe_metal::Reporter.new(*options)
 
           # Only report __Init from here if we are not instrumenting a framework.
           # Otherwise, frameworks will handle reporting __Init after full initialization

--- a/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
+++ b/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
@@ -158,7 +158,9 @@ if defined?(AppOpticsAPM::Config)
   #
   # If you're having trouble with one of the instrumentation libraries, they
   # can be individually disabled here by setting the :enabled
-  # value to false:
+  # value to false.
+  #
+  # :enabled settings are read on startup and can't be changed afterwards
   #
   AppOpticsAPM::Config[:action_controller][:enabled] = true
   AppOpticsAPM::Config[:action_controller_api][:enabled] = true

--- a/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
+++ b/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
@@ -31,7 +31,7 @@ if defined?(AppOpticsAPM::Config)
   # It takes the following values:
   # 0 fatal, 1 error, 2 warning, 3 info (the default), 4 debug low, 5 debug medium, 6 debug high.
   #
-  # AppOpticsAPM::Config[:debug_level] = 3
+  AppOpticsAPM::Config[:debug_level] = 3
 
   #
   # Set APPOPTICS_GEM_VERBOSE
@@ -39,9 +39,8 @@ if defined?(AppOpticsAPM::Config)
   #
   # On startup the components that are being instrumented will be reported if this is set to true.
   # If true and the log level is 4 or higher this may create extra debug log messages
-  # Default: false
   #
-  # AppOpticsAPM::Config[:verbose] = false
+  AppOpticsAPM::Config[:verbose] = false
 
   #
   # Turn tracing on or off

--- a/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
+++ b/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
@@ -8,6 +8,7 @@
 
 if defined?(AppOpticsAPM::Config)
 
+  # :service_key, :hostname_alias, and :debug_level are startup settings and can't be changed afterwards.
   #
   # Set APPOPTICS_SERVICE_KEY
   # This Setting will be overridden if APPOPTICS_SERVICE_KEY is set as an environment variable.
@@ -34,7 +35,7 @@ if defined?(AppOpticsAPM::Config)
   #
   AppOpticsAPM::Config[:debug_level] = 3
   #
-  # The level will be used in the c-extension of the gem and also mapped to the
+  # :debug_level will be used in the c-extension of the gem and also mapped to the
   # Ruby logger as FATAL, ERROR, WARN, INFO, or DEBUG
   # The Ruby logger can afterwards be changed to a different level as follows:
   # AppOpticsAPM.logger.level = Logger::INFO

--- a/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
+++ b/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
@@ -9,6 +9,41 @@
 if defined?(AppOpticsAPM::Config)
 
   #
+  # Set APPOPTICS_SERVICE_KEY
+  # This Setting will be overridden if APPOPTICS_SERVICE_KEY is set as an environment variable.
+  # This is a required setting. If the service key is not set here it needs to be set as environment variable.
+  #
+  # The service key is a combination of the API token plus a service name.
+  # E.g.: a4770c19-2503-439a-836e-a0ab5eb5b00f:rails_app
+  #
+  # AppOpticsAPM::Config[:service_key] = '11111111-1111-1111-1111-111111111111:the_service_name'
+
+  #
+  # Set APPOPTICS_HOSTNAME_ALIAS
+  # This Setting will be overridden if APPOPTICS_HOSTNAME_ALIAS is set as an environment variable
+  #
+  # AppOpticsAPM::Config[:hostname_alias] = 'service_name'
+
+  #
+  # Set APPOPTICS_DEBUG_LEVEL
+  # This Setting will be overridden if APPOPTICS_DEBUG_LEVEL is set as an environment variable
+  #
+  # It takes the following values:
+  # 0 fatal, 1 error, 2 warning, 3 info (the default), 4 debug low, 5 debug medium, 6 debug high.
+  #
+  # AppOpticsAPM::Config[:debug_level] = 3
+
+  #
+  # Set APPOPTICS_GEM_VERBOSE
+  # This Setting will be overridden if APPOPTICS_GEM_VERBOSE is set as an environment variable
+  #
+  # On startup the components that are being instrumented will be reported if this is set to true.
+  # If true and the log level is 4 or higher this may create extra debug log messages
+  # Default: false
+  #
+  # AppOpticsAPM::Config[:verbose] = false
+
+  #
   # Turn tracing on or off
   #
   # By default tracing is set to 'always', the other option is 'never'.
@@ -16,11 +51,6 @@ if defined?(AppOpticsAPM::Config)
   # sampling rate. 'never' means that there is no sampling.
   #
   AppOpticsAPM::Config[:tracing_mode] = :always
-
-  #
-  # Verbose output of instrumentation initialization
-  #
-  AppOpticsAPM::Config[:verbose] = ENV.key?('APPOPTICS_GEM_VERBOSE') && ENV['APPOPTICS_GEM_VERBOSE'] == 'true' ? true : false
 
   #
   # Prepend domain to transaction name

--- a/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
+++ b/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
@@ -14,24 +14,30 @@ if defined?(AppOpticsAPM::Config)
   # This is a required setting. If the service key is not set here it needs to be set as environment variable.
   #
   # The service key is a combination of the API token plus a service name.
-  # E.g.: a4770c19-2503-439a-836e-a0ab5eb5b00f:rails_app
+  # E.g.: 0123456789abcde0123456789abcde0123456789abcde0123456789abcde1234:my_service
   #
-  # AppOpticsAPM::Config[:service_key] = '11111111-1111-1111-1111-111111111111:the_service_name'
+  # AppOpticsAPM::Config[:service_key] = '0123456789abcde0123456789abcde0123456789abcde0123456789abcde1234:my_service'
 
   #
   # Set APPOPTICS_HOSTNAME_ALIAS
   # This Setting will be overridden if APPOPTICS_HOSTNAME_ALIAS is set as an environment variable
   #
-  # AppOpticsAPM::Config[:hostname_alias] = 'service_name'
+  # AppOpticsAPM::Config[:hostname_alias] = 'alias_name'
 
   #
   # Set APPOPTICS_DEBUG_LEVEL
   # This Setting will be overridden if APPOPTICS_DEBUG_LEVEL is set as an environment variable
   #
-  # It takes the following values:
-  # 0 fatal, 1 error, 2 warning, 3 info (the default), 4 debug low, 5 debug medium, 6 debug high.
+  # It sets the log level and takes the following values:
+  ## 0 fatal, 1 error, 2 warning, 3 info (the default), 4 debug low, 5 debug medium, 6 debug high.
+  #
   #
   AppOpticsAPM::Config[:debug_level] = 3
+  #
+  # The level will be used in the c-extension of the gem and also mapped to the
+  # Ruby logger as FATAL, ERROR, WARN, INFO, or DEBUG
+  # The Ruby logger can afterwards be changed to a different level as follows:
+  # AppOpticsAPM.logger.level = Logger::INFO
 
   #
   # Set APPOPTICS_GEM_VERBOSE

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -62,7 +62,8 @@ class ConfigTest
 
       AppOpticsAPM::Config.load_config_file
 
-      ENV['APPOPTICS_SERVICE_KEY'].must_equal '11111111-1111-1111-1111-111111111111:the_service_name'
+      ENV['APPOPTICS_SERVICE_KEY'].must_equal nil
+      AppOpticsAPM::Config[:service_key].must_equal '11111111-1111-1111-1111-111111111111:the_service_name'
       ENV['APPOPTICS_HOSTNAME_ALIAS'].must_equal 'my_service'
       # logging happens in 2 places, oboe and ruby, we translate
       ENV['APPOPTICS_DEBUG_LEVEL'].must_equal '6'
@@ -87,26 +88,11 @@ class ConfigTest
        AppOpticsAPM::Config.load_config_file
 
        ENV['APPOPTICS_SERVICE_KEY'].must_equal '22222222-2222-2222-2222-222222222222:the_service_name'
+       AppOpticsAPM::Config[:service_key].must_equal '22222222-2222-2222-2222-222222222222:the_service_name'
        ENV['APPOPTICS_HOSTNAME_ALIAS'].must_equal 'my_other_service'
        ENV['APPOPTICS_DEBUG_LEVEL'].must_equal '2'
        AppOpticsAPM.logger.level.must_equal Logger::WARN
        AppOpticsAPM::Config[:verbose].must_equal true
-    end
-
-    it 'should barf when there is a wrong type for SERVICE_KEY' do
-      File.open(@@default_config_path, 'w') do |f|
-        f.puts "AppOpticsAPM::Config[:service_key] = 123"
-      end
-
-      proc { AppOpticsAPM::Config.load_config_file }.must_raise TypeError
-    end
-
-    it 'should barf when there is a wrong type for HOSTNAME_ALIAS' do
-      File.open(@@default_config_path, 'w') do |f|
-        f.puts "AppOpticsAPM::Config[:hostname_alias] = 123"
-      end
-
-      proc { AppOpticsAPM::Config.load_config_file }.must_raise TypeError
     end
 
     it 'should use default when there is a wrong debug level setting' do

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -143,7 +143,6 @@ class ConfigTest
     end
 
     it 'should have the correct instrumentation defaults' do
-      ENV['APPOPTICS_GEM_VERBOSE'] = 'true'
       # Reset AppOpticsAPM::Config to defaults
       AppOpticsAPM::Config.initialize
 

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -147,8 +147,9 @@ class ConfigTest
       # Reset AppOpticsAPM::Config to defaults
       AppOpticsAPM::Config.initialize
 
+      AppOpticsAPM::Config[:debug_level] = 3
+      AppOpticsAPM::Config[:verbose].must_equal false
       AppOpticsAPM::Config[:tracing_mode].must_equal :always
-      AppOpticsAPM::Config[:verbose].must_equal true
       AppOpticsAPM::Config[:sanitize_sql].must_equal true
       AppOpticsAPM::Config[:sanitize_sql_regexp].must_equal '(\'[\s\S][^\']*\'|\d*\.\d+|\d+|NULL)'
       AppOpticsAPM::Config[:sanitize_sql_opts].must_equal Regexp::IGNORECASE

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -15,6 +15,8 @@ class ConfigTest
     FileUtils.mkdir_p(File.join(Dir.pwd, 'config', 'initializers'))
 
     before do
+      @tracing_mode = AppOpticsAPM::Config[:tracing_mode]
+      @sample_rate = AppOpticsAPM::Config[:sample_rate]
       @gem_verbose =  AppOpticsAPM::Config[:verbose]
 
       ENV.delete('APPOPTICS_APM_CONFIG_RUBY')
@@ -34,9 +36,8 @@ class ConfigTest
     end
 
     after do
-      # Set back to always trace mode
-      AppOpticsAPM::Config[:tracing_mode] = "always"
-      AppOpticsAPM::Config[:sample_rate] = 1000000
+      AppOpticsAPM::Config[:tracing_mode] = @tracing_mode
+      AppOpticsAPM::Config[:sample_rate] = @sample_rate
       AppOpticsAPM::Config[:verbose] = @gem_verbose
     end
 

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -15,7 +15,19 @@ class ConfigTest
     FileUtils.mkdir_p(File.join(Dir.pwd, 'config', 'initializers'))
 
     before do
+      @gem_verbose =  AppOpticsAPM::Config[:verbose]
+
       ENV.delete('APPOPTICS_APM_CONFIG_RUBY')
+      ENV.delete('APPOPTICS_SERVICE_KEY')
+      ENV.delete('APPOPTICS_HOSTNAME_ALIAS')
+      ENV.delete('APPOPTICS_DEBUG_LEVEL')
+      ENV.delete('APPOPTICS_GEM_VERBOSE')
+
+      AppOpticsAPM::Config[:service_key] = nil
+      AppOpticsAPM::Config[:hostname_alias] = nil
+      AppOpticsAPM::Config[:debug_level] = nil
+      AppOpticsAPM::Config[:verbose] = nil
+
       FileUtils.rm(@@default_config_path, :force => true)
       FileUtils.rm(@@rails_config_path, :force => true)
       FileUtils.rm(@@test_config_path, :force => true)
@@ -25,24 +37,118 @@ class ConfigTest
       # Set back to always trace mode
       AppOpticsAPM::Config[:tracing_mode] = "always"
       AppOpticsAPM::Config[:sample_rate] = 1000000
+      AppOpticsAPM::Config[:verbose] = @gem_verbose
     end
 
     after(:all) do
       AppOpticsAPM::Config[:tracing_mode] = "always"
       AppOpticsAPM::Config[:sample_rate] = 1000000
       ENV.delete('APPOPTICS_APM_CONFIG_RUBY')
+      ENV.delete('APPOPTICS_SERVICE_KEY')
+      ENV.delete('APPOPTICS_HOSTNAME_ALIAS')
+      ENV.delete('APPOPTICS_DEBUG_LEVEL')
       FileUtils.rm(@@default_config_path, :force => true)
       FileUtils.rm(@@rails_config_path, :force => true)
       FileUtils.rm(@@test_config_path, :force => true)
     end
 
+    it 'should use the config file settings for env vars' do
+      File.open(@@default_config_path, 'w') do |f|
+        f.puts "AppOpticsAPM::Config[:service_key] = '11111111-1111-1111-1111-111111111111:the_service_name'"
+        f.puts "AppOpticsAPM::Config[:hostname_alias] = 'my_service'"
+        f.puts "AppOpticsAPM::Config[:debug_level] = 6"
+        f.puts "AppOpticsAPM::Config[:verbose] = true"
+      end
+
+      AppOpticsAPM::Config.load_config_file
+
+      ENV['APPOPTICS_SERVICE_KEY'].must_equal '11111111-1111-1111-1111-111111111111:the_service_name'
+      ENV['APPOPTICS_HOSTNAME_ALIAS'].must_equal 'my_service'
+      # logging happens in 2 places, oboe and ruby, we translate
+      ENV['APPOPTICS_DEBUG_LEVEL'].must_equal '6'
+      AppOpticsAPM.logger.level.must_equal Logger::DEBUG
+      # the verbose setting is only relevant for ruby, no need to update the env var
+      AppOpticsAPM::Config[:verbose].must_equal true
+    end
+
+    it 'should NOT override env vars with config file settings' do
+       ENV['APPOPTICS_SERVICE_KEY'] = '22222222-2222-2222-2222-222222222222:the_service_name'
+       ENV['APPOPTICS_HOSTNAME_ALIAS'] = 'my_other_service'
+       ENV['APPOPTICS_DEBUG_LEVEL'] = '2'
+       ENV['APPOPTICS_GEM_VERBOSE'] = 'TRUE'
+
+       File.open(@@default_config_path, 'w') do |f|
+         f.puts "AppOpticsAPM::Config[:service_key] = '11111111-1111-1111-1111-111111111111:the_service_name'"
+         f.puts "AppOpticsAPM::Config[:hostname_alias] = 'my_service'"
+         f.puts "AppOpticsAPM::Config[:debug_level] = 6"
+         f.puts "AppOpticsAPM::Config[:verbose] = true"
+       end
+
+       AppOpticsAPM::Config.load_config_file
+
+       ENV['APPOPTICS_SERVICE_KEY'].must_equal '22222222-2222-2222-2222-222222222222:the_service_name'
+       ENV['APPOPTICS_HOSTNAME_ALIAS'].must_equal 'my_other_service'
+       ENV['APPOPTICS_DEBUG_LEVEL'].must_equal '2'
+       AppOpticsAPM.logger.level.must_equal Logger::WARN
+       AppOpticsAPM::Config[:verbose].must_equal true
+    end
+
+    it 'should barf when there is a wrong type for SERVICE_KEY' do
+      File.open(@@default_config_path, 'w') do |f|
+        f.puts "AppOpticsAPM::Config[:service_key] = 123"
+      end
+
+      proc { AppOpticsAPM::Config.load_config_file }.must_raise TypeError
+    end
+
+    it 'should barf when there is a wrong type for HOSTNAME_ALIAS' do
+      File.open(@@default_config_path, 'w') do |f|
+        f.puts "AppOpticsAPM::Config[:hostname_alias] = 123"
+      end
+
+      proc { AppOpticsAPM::Config.load_config_file }.must_raise TypeError
+    end
+
+    it 'should use default when there is a wrong debug level setting' do
+      File.open(@@default_config_path, 'w') do |f|
+        f.puts "AppOpticsAPM::Config[:debug_level] = 7"
+      end
+
+      AppOpticsAPM::Config.load_config_file
+
+      ENV['APPOPTICS_DEBUG_LEVEL'].must_equal '3'
+      AppOpticsAPM.logger.level.must_equal Logger::INFO
+    end
+
+    it "should only accept 'true'/'TRUE'/'True'/... as true for VERBOSE" do
+      File.open(@@default_config_path, 'w') do |f|
+        f.puts "AppOpticsAPM::Config[:debug_level] = 7"
+      end
+
+      ENV['APPOPTICS_GEM_VERBOSE'] = 'FALSE'
+      AppOpticsAPM::Config.load_config_file
+      AppOpticsAPM::Config[:verbose].wont_equal true
+
+      ENV['APPOPTICS_GEM_VERBOSE'] = 'TRUE'
+      AppOpticsAPM::Config.load_config_file
+      AppOpticsAPM::Config[:verbose].must_equal true
+
+      ENV['APPOPTICS_GEM_VERBOSE'] = 'verbose'
+      AppOpticsAPM::Config.load_config_file
+      AppOpticsAPM::Config[:verbose].wont_equal true
+
+      ENV['APPOPTICS_GEM_VERBOSE'] = 'True'
+      AppOpticsAPM::Config.load_config_file
+      AppOpticsAPM::Config[:verbose].must_equal true
+    end
+
     it 'should have the correct instrumentation defaults' do
+      ENV['APPOPTICS_GEM_VERBOSE'] = 'true'
       # Reset AppOpticsAPM::Config to defaults
       AppOpticsAPM::Config.initialize
 
       AppOpticsAPM::Config[:tracing_mode].must_equal :always
-      AppOpticsAPM::Config[:verbose].must_equal ENV.key?('APPOPTICS_GEM_VERBOSE') && ENV['APPOPTICS_GEM_VERBOSE'] == 'true' ? true : false
-
+      AppOpticsAPM::Config[:verbose].must_equal true
       AppOpticsAPM::Config[:sanitize_sql].must_equal true
       AppOpticsAPM::Config[:sanitize_sql_regexp].must_equal '(\'[\s\S][^\']*\'|\d*\.\d+|\d+|NULL)'
       AppOpticsAPM::Config[:sanitize_sql_opts].must_equal Regexp::IGNORECASE

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -39,6 +39,7 @@ class ConfigTest
       AppOpticsAPM::Config[:tracing_mode] = @tracing_mode
       AppOpticsAPM::Config[:sample_rate] = @sample_rate
       AppOpticsAPM::Config[:verbose] = @gem_verbose
+      FileUtils.rm_f(@@default_config_path)
     end
 
     after(:all) do

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -62,18 +62,18 @@ class ConfigTest
 
       AppOpticsAPM::Config.load_config_file
 
-      ENV['APPOPTICS_SERVICE_KEY'].must_equal nil
+      ENV['APPOPTICS_SERVICE_KEY'].must_be_nil
       AppOpticsAPM::Config[:service_key].must_equal '11111111-1111-1111-1111-111111111111:the_service_name'
 
-      ENV['APPOPTICS_HOSTNAME_ALIAS'].must_equal nil
+      ENV['APPOPTICS_HOSTNAME_ALIAS'].must_be_nil
       AppOpticsAPM::Config[:hostname_alias].must_equal 'my_service'
 
       # logging happens in 2 places, oboe and ruby, we translate
-      ENV['APPOPTICS_DEBUG_LEVEL'].must_equal nil
+      ENV['APPOPTICS_DEBUG_LEVEL'].must_be_nil
       AppOpticsAPM::Config[:debug_level].must_equal 6
       AppOpticsAPM.logger.level.must_equal Logger::DEBUG
 
-      ENV['APPOPTICS_GEM_VERBOSE'].must_equal nil
+      ENV['APPOPTICS_GEM_VERBOSE'].must_be_nil
       AppOpticsAPM::Config[:verbose].must_equal true
     end
 
@@ -107,8 +107,8 @@ class ConfigTest
 
       AppOpticsAPM::Config.load_config_file
 
-      ENV['APPOPTICS_DEBUG_LEVEL'].must_equal nil
-      AppOpticsAPM::Config[:debug_level].must_equal nil
+      ENV['APPOPTICS_DEBUG_LEVEL'].must_be_nil
+      AppOpticsAPM::Config[:debug_level].must_be_nil
       AppOpticsAPM.logger.level.must_equal Logger::INFO
     end
 

--- a/test/unit/api_sdk/metrics_test.rb
+++ b/test/unit/api_sdk/metrics_test.rb
@@ -6,6 +6,9 @@ require 'mocha/minitest'
 
 describe AppOpticsAPM::API::Metrics do
   describe 'send_metrics' do
+    before do
+      AppOpticsAPM.transaction_name = nil
+    end
 
     it 'should send the correct duration and create a transaction name' do
       Time.stub(:now, Time.at(0)) do
@@ -22,7 +25,7 @@ describe AppOpticsAPM::API::Metrics do
       assert_equal 42, result
     end
 
-    it 'should override the transaction name from the params' do
+    it 'should override the transaction name from the params for createSpan' do
       Time.stub(:now, Time.at(0)) do
         AppOpticsAPM::Span.expects(:createSpan).with('this_name', nil, 0)
 

--- a/test/unit/api_sdk/sdk_test.rb
+++ b/test/unit/api_sdk/sdk_test.rb
@@ -451,17 +451,17 @@ describe AppOpticsAPM::SDK do
 
   describe 'appoptics_ready?' do
     it 'should return true if it can connect' do
-      AppopticsAPM::Context.expects(:isReady).with(10_000).returns(true)
+      AppopticsAPM::Context.expects(:isReady).with(10_000).returns(1)
       assert AppOpticsAPM::SDK.appoptics_ready?(10_000)
     end
 
     it 'should work with no arg' do
-      AppopticsAPM::Context.expects(:isReady).returns(true)
+      AppopticsAPM::Context.expects(:isReady).returns(1)
       assert AppOpticsAPM::SDK.appoptics_ready?
     end
 
     it 'should return false if it cannot connect' do
-      AppopticsAPM::Context.expects(:isReady).returns(false)
+      AppopticsAPM::Context.expects(:isReady).returns(2)
       refute AppOpticsAPM::SDK.appoptics_ready?
     end
   end


### PR DESCRIPTION
- update config file template with new settings and explanatory comments
- add code to read new settings
- make sure there is test coverage for precedence of ENV vars over config file settings and defaults
- load config file before initializing oboe and set tracing_mode afterwards
