### PR TITLE
fix faraday edges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,7 @@ gemfile:
   - gemfiles/instrumentation_mocked_oldgems.gemfile
   - gemfiles/frameworks.gemfile
   - gemfiles/rails52.gemfile
-  - gemfiles/rails51.gemfile
   - gemfiles/rails42.gemfile
-##  - gemfiles/rails32.gemfile # We currently are not supporting Rails 3.2
   - gemfiles/delayed_job.gemfile
   - gemfiles/noop.gemfile
 
@@ -69,20 +67,6 @@ matrix:
       env: DBTYPE=mysql2
     - gemfile: gemfiles/delayed_job.gemfile
       env: DBTYPE=mysql2
-
-    # Rails 3.2 is not compatible with Ruby >= 2.4
-    # We currently are not supporting Rails 3.2
-#    - rvm: 2.5.1
-#      gemfile: gemfiles/rails32.gemfile
-#    - rvm: 2.4.4
-#      gemfile: gemfiles/rails32.gemfile
-
-#    - rvm: jruby-9.0.5.0
-#      gemfile: gemfiles/delayed_job.gemfile
-
-    # Skip testing on JRuby until activerecord-jdbc supports Rails 5.0
-#    - rvm: jruby-9.0.5.0
-#      gemfile: gemfiles/rails50.gemfile
 
 # FIXME: Figure out if this is still an issue when reviewing cassandra test setup
 # Attempt Travis/Cassandra fix re: https://github.com/travis-ci/travis-ci/issues/1484

--- a/appoptics_apm.gemspec
+++ b/appoptics_apm.gemspec
@@ -12,9 +12,18 @@ Gem::Specification.new do |s|
   s.email = %q{support@appoptics.com}
   s.homepage = %q{https://www.appoptics.com/}
   s.summary = %q{AppOptics APM performance instrumentation gem for Ruby}
-  s.description = %q{The AppOpticsAPM gem provides performance instrumentation for MRI Ruby and related frameworks.}
+  s.description = <<-EOF
+     The appoptics_apm gem provides automatic tracing and metrics for Ruby applications. Get started at appoptics.com. @AppOptics
+  EOF
 
-  s.extra_rdoc_files = ["LICENSE"]
+  s.metadata = {
+      'changelog_uri'     => 'https://github.com/appoptics/appoptics-apm-ruby/releases',
+      'documentation_uri' => 'https://docs.appoptics.com/kb/apm_tracing/ruby/',
+      'homepage_uri'      => 'https://www.appoptics.com/',
+      'source_code_uri'   => 'https://github.com/appoptics/appoptics-apm-ruby',
+  }
+
+  s.extra_rdoc_files = ['LICENSE']
   s.files = `git ls-files`.split("\n").reject { |f| f.match(%r{^(test|gemfiles)/}) }
   s.files += ['ext/oboe_metal/src/oboe.h',
               'ext/oboe_metal/src/oboe.hpp',

--- a/gemfiles/instrumentation_mocked.gemfile
+++ b/gemfiles/instrumentation_mocked.gemfile
@@ -19,6 +19,7 @@ gem 'excon'
 gem 'faraday'
 gem 'httpclient'
 gem 'typhoeus'
+gem 'patron' # not instrumented, to test non-instrumented faraday adapter
 
 gemspec :path => File.expand_path(File.dirname(__FILE__) + '/../')
 # vim:syntax=ruby

--- a/gemfiles/instrumentation_mocked_oldgems.gemfile
+++ b/gemfiles/instrumentation_mocked_oldgems.gemfile
@@ -21,6 +21,7 @@ gem 'excon', '0.28.0'
 gem 'faraday', '0.7.6'
 gem 'httpclient', '2.3.0'
 gem 'typhoeus', '0.6.2'
+gem 'patron', '0.7.0' # not instrumented, to test non-instrumented faraday adapter
 
 gemspec :path => File.expand_path(File.dirname(__FILE__) + '/../')
 # vim:syntax=ruby

--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem 'moped'
 gem 'eventmachine', '< 1.2.0'
 gem 'em-synchrony'
-gem 'em-http-request'
+# gem 'em-http-request'
 gem 'rest-client'
 gem 'grpc'
 
@@ -36,6 +36,7 @@ gem 'excon'
 gem 'faraday'
 gem 'httpclient'
 gem 'memcached'
+gem 'patron' # not instrumented, to test non-instrumented faraday adapter
 gem 'redis'
 gem 'resque' unless defined?(JRUBY_VERSION)
 gem 'sequel'

--- a/lib/appoptics_apm/inst/httpclient.rb
+++ b/lib/appoptics_apm/inst/httpclient.rb
@@ -12,6 +12,7 @@ module AppOpticsAPM
 
       def appoptics_collect(method, uri, query = nil)
         kvs = {}
+        kvs[:Spec] = 'rsc'
         kvs[:IsService] = 1
 
         # Conditionally log URL query params
@@ -27,9 +28,6 @@ module AppOpticsAPM
           kvs[:RemoteURL] = uri.to_s.split('?').first
         end
 
-        kvs[:RemoteProtocol] = uri.scheme.upcase
-        kvs[:RemoteHost] = "#{uri.host}:#{uri.port}"
-        kvs[:ServiceArg] = "/?#{uri.query}"
         kvs[:HTTPMethod] = ::AppOpticsAPM::Util.upcase(method)
         kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:httpclient][:collect_backtraces]
         kvs

--- a/lib/appoptics_apm/sdk.rb
+++ b/lib/appoptics_apm/sdk.rb
@@ -178,7 +178,8 @@ module AppOpticsAPM
           return result
         end
 
-        transaction_name_from_opts(opts)
+        # :TransactionName and 'TransactionName' need to be removed from opts
+        AppOpticsAPM.transaction_name = opts.delete('TransactionName') || opts.delete(:TransactionName)
 
         AppOpticsAPM::API.log_start(span, xtrace, opts)
         # AppOpticsAPM::Event.startTrace creates an Event without an Edge
@@ -293,6 +294,7 @@ module AppOpticsAPM
       #   end
       #
       def appoptics_ready?(wait_milliseconds = 3000)
+        return false unless AppOpticsAPM.loaded
         # These codes are returned by isReady:
         # OBOE_SERVER_RESPONSE_UNKNOWN 0
         # OBOE_SERVER_RESPONSE_OK 1
@@ -301,21 +303,6 @@ module AppOpticsAPM
         # OBOE_SERVER_RESPONSE_INVALID_API_KEY 4
         # OBOE_SERVER_RESPONSE_CONNECT_ERROR 5
         AppopticsAPM::Context.isReady(wait_milliseconds) == 1
-      end
-
-      private
-      # private method
-      #
-      # This should only be called at the beginning of a transaction,
-      # when AppOpticsAPM.transaction_name needs to be set to nil
-      # or whatever is provided in the opts
-      def transaction_name_from_opts(opts)
-        # :TransactionName and 'TransactionName' need to be removed from opts
-        # :TransactionName should only be sent after it is set by send_metrics
-        transaction_name = opts.delete('TransactionName')
-        transaction_name = opts.delete(:TransactionName) || transaction_name
-
-        AppOpticsAPM.transaction_name = transaction_name
       end
     end
 

--- a/test/instrumentation/bunny_consumer_test.rb
+++ b/test/instrumentation/bunny_consumer_test.rb
@@ -45,13 +45,13 @@ unless defined?(JRUBY_VERSION)
 
       traces = get_all_traces
 
-      traces.count.must_equal 12
-      assert valid_edges?(traces), "Invalid edge in traces"
+      traces.count.must_equal 11
+      assert valid_edges?(traces, false), "Invalid edge in traces"
 
       traces[5]['Layer'].must_equal "net-http"
       traces[5]['Label'].must_equal "entry"
-      traces[10]['Layer'].must_equal "net-http"
-      traces[10]['Label'].must_equal "exit"
+      traces[9]['Layer'].must_equal "net-http"
+      traces[9]['Label'].must_equal "exit"
 
       traces[4]['Spec'].must_equal "job"
       traces[4]['Flavor'].must_equal "rabbitmq"
@@ -90,15 +90,15 @@ unless defined?(JRUBY_VERSION)
       sleep 1
 
       traces = get_all_traces
-      traces.count.must_equal 8
+      traces.count.must_equal 7
 
       validate_outer_layers(traces, "rabbitmq-consumer")
       assert valid_edges?(traces), "Invalid edge in traces"
 
       traces[1]['Layer'].must_equal "net-http"
       traces[1]['Label'].must_equal "entry"
-      traces[6]['Layer'].must_equal "net-http"
-      traces[6]['Label'].must_equal "exit"
+      traces[5]['Layer'].must_equal "net-http"
+      traces[5]['Label'].must_equal "exit"
 
       traces[0]['Spec'].must_equal "job"
       traces[0]['Flavor'].must_equal "rabbitmq"
@@ -182,8 +182,8 @@ unless defined?(JRUBY_VERSION)
 
       traces = get_all_traces
 
-      traces.count.must_equal 12
-      assert valid_edges?(traces), "Invalid edge in traces"
+      traces.count.must_equal 11
+      assert valid_edges?(traces, false), "Invalid edge in traces"
 
       traces[4]['Spec'].must_equal "job"
       traces[4]['Flavor'].must_equal "rabbitmq"

--- a/test/instrumentation/faraday_test.rb
+++ b/test/instrumentation/faraday_test.rb
@@ -7,10 +7,12 @@ describe "Faraday" do
   before do
     clear_all_traces
     @collect_backtraces = AppOpticsAPM::Config[:faraday][:collect_backtraces]
+    @log_args = AppOpticsAPM::Config[:faraday][:log_args]
   end
 
   after do
     AppOpticsAPM::Config[:faraday][:collect_backtraces] = @collect_backtraces
+    AppOpticsAPM::Config[:faraday][:log_args] = @log_args
   end
 
   it 'Faraday should be defined and ready' do
@@ -33,26 +35,54 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 11
+    traces.count.must_equal 9
 
+    assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
 
     traces[1]['Layer'].must_equal 'faraday'
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:faraday][:collect_backtraces]
 
     traces[6]['Layer'].must_equal 'net-http'
+    traces[6]['Label'].must_equal 'exit'
+    traces[6]['Spec'].must_equal 'rsc'
     traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteProtocol'].must_equal 'HTTP'
-    traces[6]['RemoteHost'].must_equal '127.0.0.1:8101'
-    traces[6]['ServiceArg'].must_equal '/games?q=1'
+    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/games?q=1'
     traces[6]['HTTPMethod'].must_equal 'GET'
     traces[6]['HTTPStatus'].must_equal '200'
 
-    traces[7]['Layer'].must_equal 'net-http'
+    traces[7]['Layer'].must_equal 'faraday'
     traces[7]['Label'].must_equal 'exit'
+  end
 
-    traces[8]['Layer'].must_equal 'faraday'
-    traces[9]['Label'].must_equal 'exit'
+  it "should trace UNINSTRUMENTED cross-app request" do
+    AppOpticsAPM::API.start_trace('faraday_test') do
+      conn = Faraday.new(:url => 'http://127.0.0.1:8110') do |faraday|
+        faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
+      end
+      response = conn.get '/games?q=1'
+      response.headers["x-trace"].wont_match nil
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 6
+
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, 'faraday_test')
+
+    traces[1]['Layer'].must_equal 'faraday'
+    traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:faraday][:collect_backtraces]
+
+    traces[3]['Layer'].must_equal 'net-http'
+    traces[3]['Label'].must_equal 'exit'
+    traces[3]['Spec'].must_equal 'rsc'
+    traces[3]['IsService'].must_equal 1
+    traces[3]['RemoteURL'].must_equal 'http://127.0.0.1:8110/games?q=1'
+    traces[3]['HTTPMethod'].must_equal 'GET'
+    traces[3]['HTTPStatus'].must_equal '200'
+
+    traces[4]['Layer'].must_equal 'faraday'
+    traces[4]['Label'].must_equal 'exit'
   end
 
   it 'should trace a Faraday request' do
@@ -64,7 +94,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 11
+    traces.count.must_equal 9
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -73,22 +103,15 @@ describe "Faraday" do
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:faraday][:collect_backtraces]
 
     traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'info'
+    traces[6]['Label'].must_equal 'exit'
+    traces[6]['Spec'].must_equal 'rsc'
     traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteProtocol'].must_equal 'HTTP'
-    traces[6]['RemoteHost'].must_equal '127.0.0.1:8101'
-    traces[6]['ServiceArg'].must_equal '/?q=ruby_test_suite'
+    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=ruby_test_suite'
     traces[6]['HTTPMethod'].must_equal 'GET'
     traces[6]['HTTPStatus'].must_equal '200'
 
-    traces[7]['Layer'].must_equal 'net-http'
+    traces[7]['Layer'].must_equal 'faraday'
     traces[7]['Label'].must_equal 'exit'
-
-    traces[8]['Layer'].must_equal 'faraday'
-    traces[8]['Label'].must_equal 'info'
-
-    traces[9]['Layer'].must_equal 'faraday'
-    traces[9]['Label'].must_equal 'exit'
   end
 
   it 'should trace a Faraday class style request' do
@@ -97,7 +120,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 11
+    traces.count.must_equal 9
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -106,22 +129,15 @@ describe "Faraday" do
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:faraday][:collect_backtraces]
 
     traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'info'
+    traces[6]['Label'].must_equal 'exit'
+    traces[6]['Spec'].must_equal 'rsc'
     traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteProtocol'].must_equal 'HTTP'
-    traces[6]['RemoteHost'].must_equal '127.0.0.1:8101'
-    traces[6]['ServiceArg'].must_equal '/?a=1'
+    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?a=1'
     traces[6]['HTTPMethod'].must_equal 'GET'
     traces[6]['HTTPStatus'].must_equal '200'
 
-    traces[7]['Layer'].must_equal 'net-http'
+    traces[7]['Layer'].must_equal 'faraday'
     traces[7]['Label'].must_equal 'exit'
-
-    traces[8]['Layer'].must_equal 'faraday'
-    traces[8]['Label'].must_equal 'info'
-
-    traces[9]['Layer'].must_equal 'faraday'
-    traces[9]['Label'].must_equal 'exit'
   end
 
   it 'should trace a Faraday with the excon adapter' do
@@ -133,7 +149,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 10
+    traces.count.must_equal 9
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -143,22 +159,21 @@ describe "Faraday" do
 
     traces[2]['Layer'].must_equal 'excon'
     traces[2]['Label'].must_equal 'entry'
+    traces[2]['Spec'].must_equal 'rsc'
     traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].must_equal 'HTTP'
-    traces[2]['RemoteHost'].must_equal '127.0.0.1'
-    traces[2]['ServiceArg'].must_equal '/?q=1'
+    traces[2]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
     traces[2]['HTTPMethod'].must_equal 'GET'
 
+    traces[2]['RemoteProtocol'].must_be_nil
+    traces[2]['RemoteHost'].must_be_nil
+    traces[2]['ServiceArg'].must_be_nil
     traces[6]['Layer'].must_equal 'excon'
     traces[6]['Label'].must_equal 'exit'
     traces[6]['HTTPStatus'].must_equal 200
 
     traces[7]['Layer'].must_equal 'faraday'
-    traces[7]['Label'].must_equal 'info'
+    traces[7]['Label'].must_equal 'exit'
     traces[7]['Middleware'].must_equal '[Faraday::Adapter::Excon]'
-
-    traces[8]['Layer'].must_equal 'faraday'
-    traces[8]['Label'].must_equal 'exit'
   end
 
   it 'should trace a Faraday with the httpclient adapter' do
@@ -170,7 +185,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 10
+    traces.count.must_equal 9
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -180,10 +195,9 @@ describe "Faraday" do
 
     traces[2]['Layer'].must_equal 'httpclient'
     traces[2]['Label'].must_equal 'entry'
+    traces[2]['Spec'].must_equal 'rsc'
     traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].must_equal 'HTTP'
-    traces[2]['RemoteHost'].must_equal '127.0.0.1:8101'
-    traces[2]['ServiceArg'].must_equal '/?q=1'
+    traces[2]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
     traces[2]['HTTPMethod'].must_equal 'GET'
 
     traces[6]['Layer'].must_equal 'httpclient'
@@ -191,11 +205,104 @@ describe "Faraday" do
     traces[6]['HTTPStatus'].must_equal 200
 
     traces[7]['Layer'].must_equal 'faraday'
-    traces[7]['Label'].must_equal 'info'
+    traces[7]['Label'].must_equal 'exit'
     traces[7]['Middleware'].must_equal '[Faraday::Adapter::HTTPClient]'
+  end
 
-    traces[8]['Layer'].must_equal 'faraday'
-    traces[8]['Label'].must_equal 'exit'
+  it 'should trace a Faraday with the typhoeus adapter' do
+    AppOpticsAPM::API.start_trace('faraday_test') do
+      conn = Faraday.new(:url => 'http://127.0.0.1:8101') do |faraday|
+        faraday.adapter :typhoeus
+      end
+      conn.get '/?q=1'
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 9
+
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, 'faraday_test')
+
+    traces[1]['Layer'].must_equal 'faraday'
+    traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:faraday][:collect_backtraces]
+
+    traces[2]['Layer'].must_equal 'typhoeus'
+    traces[2]['Label'].must_equal 'entry'
+
+    traces[6]['Layer'].must_equal 'typhoeus'
+    traces[6]['Label'].must_equal 'exit'
+    traces[6]['Spec'].must_equal 'rsc'
+    traces[6]['IsService'].must_equal 1
+    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
+    traces[6]['HTTPMethod'].must_equal 'GET'
+    traces[6]['HTTPStatus'].must_equal 200
+
+    traces[7]['Layer'].must_equal 'faraday'
+    traces[7]['Label'].must_equal 'exit'
+    traces[7]['Middleware'].must_equal '[Faraday::Adapter::Typhoeus]'
+  end
+
+  it 'should trace a Faraday with the UNINSTRUMENTED patron adapter' do
+    AppOpticsAPM::Config[:faraday][:log_args] = true
+    AppOpticsAPM::API.start_trace('faraday_test') do
+      conn = Faraday.new(:url => 'http://127.0.0.1:8101') do |faraday|
+        faraday.adapter :patron
+      end
+      conn.get '/?q=1'
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 7
+
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, 'faraday_test')
+
+    traces[1]['Layer'].must_equal 'faraday'
+    traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:faraday][:collect_backtraces]
+
+    traces[2]['Layer'].must_equal 'rack'
+    traces[2]['Label'].must_equal 'entry'
+
+    traces[4]['Layer'].must_equal 'rack'
+    traces[4]['Label'].must_equal 'exit'
+    traces[4]['Status'].must_equal 200
+
+    traces[5]['Spec'].must_equal 'rsc'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
+    traces[5]['HTTPMethod'].must_equal 'GET'
+    traces[5]['HTTPStatus'].must_equal 200
+    traces[5]['Layer'].must_equal 'faraday'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Middleware'].must_equal '[Faraday::Adapter::Patron]'
+  end
+
+  it 'should trace a Faraday with the UNINSTRUMENTED patron adapter to UNINSTRUMENTED rack' do
+    AppOpticsAPM::Config[:faraday][:log_args] = true
+    AppOpticsAPM::API.start_trace('faraday_test') do
+      conn = Faraday.new(:url => 'http://127.0.0.1:8110') do |faraday|
+        faraday.adapter :patron
+      end
+      conn.get '/?q=1'
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 4
+
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, 'faraday_test')
+
+    traces[1]['Layer'].must_equal 'faraday'
+    traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:faraday][:collect_backtraces]
+
+    traces[2]['Spec'].must_equal 'rsc'
+    traces[2]['IsService'].must_equal 1
+    traces[2]['RemoteURL'].must_equal 'http://127.0.0.1:8110/?q=1'
+    traces[2]['HTTPMethod'].must_equal 'GET'
+    traces[2]['HTTPStatus'].must_equal 200
+    traces[2]['Layer'].must_equal 'faraday'
+    traces[2]['Label'].must_equal 'exit'
+    traces[2]['Middleware'].must_equal '[Faraday::Adapter::Patron]'
   end
 
   it 'should obey :collect_backtraces setting when true' do

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -38,7 +38,7 @@ describe "RestClient" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 10
+    traces.count.must_equal 9
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rest_client_test')
@@ -50,20 +50,15 @@ describe "RestClient" do
     traces[2]['Label'].must_equal 'entry'
 
     traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'info'
+    traces[6]['Label'].must_equal 'exit'
     traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteProtocol'].must_equal 'HTTP'
-    traces[6]['RemoteHost'].must_equal '127.0.0.1:8101'
-    traces[6]['ServiceArg'].must_equal '/'
+    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
     traces[6]['HTTPMethod'].must_equal 'GET'
     traces[6]['HTTPStatus'].must_equal "200"
     traces[6].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[7]['Layer'].must_equal 'net-http'
+    traces[7]['Layer'].must_equal 'rest-client'
     traces[7]['Label'].must_equal 'exit'
-
-    traces[8]['Layer'].must_equal 'rest-client'
-    traces[8]['Label'].must_equal 'exit'
 
     response.headers.key?(:x_trace).wont_equal nil
     xtrace = response.headers[:x_trace]
@@ -77,7 +72,7 @@ describe "RestClient" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 10
+    traces.count.must_equal 9
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rest_client_test')
@@ -89,20 +84,15 @@ describe "RestClient" do
     traces[2]['Label'].must_equal 'entry'
 
     traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'info'
+    traces[6]['Label'].must_equal 'exit'
     traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteProtocol'].must_equal 'HTTP'
-    traces[6]['RemoteHost'].must_equal '127.0.0.1:8101'
-    traces[6]['ServiceArg'].must_equal '/?a=1'
+    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?a=1'
     traces[6]['HTTPMethod'].must_equal 'GET'
     traces[6]['HTTPStatus'].must_equal "200"
     traces[6].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[7]['Layer'].must_equal 'net-http'
+    traces[7]['Layer'].must_equal 'rest-client'
     traces[7]['Label'].must_equal 'exit'
-
-    traces[8]['Layer'].must_equal 'rest-client'
-    traces[8]['Label'].must_equal 'exit'
   end
 
   it 'should trace a raw POST request' do
@@ -111,7 +101,7 @@ describe "RestClient" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 10
+    traces.count.must_equal 9
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rest_client_test')
@@ -123,20 +113,15 @@ describe "RestClient" do
     traces[2]['Label'].must_equal 'entry'
 
     traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'info'
+    traces[6]['Label'].must_equal 'exit'
     traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteProtocol'].must_equal 'HTTP'
-    traces[6]['RemoteHost'].must_equal '127.0.0.1:8101'
-    traces[6]['ServiceArg'].must_equal '/'
+    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
     traces[6]['HTTPMethod'].must_equal 'POST'
     traces[6]['HTTPStatus'].must_equal "200"
     traces[6].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[7]['Layer'].must_equal 'net-http'
+    traces[7]['Layer'].must_equal 'rest-client'
     traces[7]['Label'].must_equal 'exit'
-
-    traces[8]['Layer'].must_equal 'rest-client'
-    traces[8]['Label'].must_equal 'exit'
   end
 
   it 'should trace a ActiveResource style GET request' do
@@ -146,7 +131,7 @@ describe "RestClient" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 10
+    traces.count.must_equal 9
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rest_client_test')
@@ -158,32 +143,25 @@ describe "RestClient" do
     traces[2]['Label'].must_equal 'entry'
 
     traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'info'
+    traces[6]['Label'].must_equal 'exit'
     traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteProtocol'].must_equal 'HTTP'
-    traces[6]['RemoteHost'].must_equal '127.0.0.1:8101'
-    traces[6]['ServiceArg'].must_equal '/?a=1'
+    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?a=1'
     traces[6]['HTTPMethod'].must_equal 'GET'
     traces[6]['HTTPStatus'].must_equal "200"
     traces[6].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[7]['Layer'].must_equal 'net-http'
+    traces[7]['Layer'].must_equal 'rest-client'
     traces[7]['Label'].must_equal 'exit'
-
-    traces[8]['Layer'].must_equal 'rest-client'
-    traces[8]['Label'].must_equal 'exit'
   end
 
   it 'should trace requests with redirects' do
-    response = nil
-
     AppOpticsAPM::API.start_trace('rest_client_test') do
       resource = RestClient::Resource.new 'http://127.0.0.1:8101/redirectme?redirect_test'
       response = resource.get
     end
 
     traces = get_all_traces
-    traces.count.must_equal 18
+    traces.count.must_equal 16
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rest_client_test')
@@ -195,42 +173,32 @@ describe "RestClient" do
     traces[2]['Label'].must_equal 'entry'
 
     traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'info'
+    traces[6]['Label'].must_equal 'exit'
     traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteProtocol'].must_equal 'HTTP'
-    traces[6]['RemoteHost'].must_equal '127.0.0.1:8101'
-    traces[6]['ServiceArg'].must_equal '/redirectme?redirect_test'
+    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/redirectme?redirect_test'
     traces[6]['HTTPMethod'].must_equal 'GET'
     traces[6]['HTTPStatus'].must_equal "301"
     traces[6].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[7]['Layer'].must_equal 'net-http'
-    traces[7]['Label'].must_equal 'exit'
+    traces[7]['Layer'].must_equal 'rest-client'
+    traces[7]['Label'].must_equal 'entry'
 
-    traces[8]['Layer'].must_equal 'rest-client'
+    traces[8]['Layer'].must_equal 'net-http'
     traces[8]['Label'].must_equal 'entry'
 
-    traces[9]['Layer'].must_equal 'net-http'
-    traces[9]['Label'].must_equal 'entry'
+    traces[12]['Layer'].must_equal 'net-http'
+    traces[12]['Label'].must_equal 'exit'
+    traces[12]['IsService'].must_equal 1
+    traces[12]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
+    traces[12]['HTTPMethod'].must_equal 'GET'
+    traces[12]['HTTPStatus'].must_equal "200"
+    traces[12].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[13]['Layer'].must_equal 'net-http'
-    traces[13]['Label'].must_equal 'info'
-    traces[13]['IsService'].must_equal 1
-    traces[13]['RemoteProtocol'].must_equal 'HTTP'
-    traces[13]['RemoteHost'].must_equal '127.0.0.1:8101'
-    traces[13]['ServiceArg'].must_equal '/'
-    traces[13]['HTTPMethod'].must_equal 'GET'
-    traces[13]['HTTPStatus'].must_equal "200"
-    traces[13].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
+    traces[13]['Layer'].must_equal 'rest-client'
+    traces[13]['Label'].must_equal 'exit'
 
-    traces[14]['Layer'].must_equal 'net-http'
+    traces[14]['Layer'].must_equal 'rest-client'
     traces[14]['Label'].must_equal 'exit'
-
-    traces[15]['Layer'].must_equal 'rest-client'
-    traces[15]['Label'].must_equal 'exit'
-
-    traces[16]['Layer'].must_equal 'rest-client'
-    traces[16]['Label'].must_equal 'exit'
   end
 
   it 'should trace and capture raised exceptions' do

--- a/test/instrumentation/sidekiq-client_test.rb
+++ b/test/instrumentation/sidekiq-client_test.rb
@@ -45,8 +45,8 @@ unless defined?(JRUBY_VERSION)
       sleep 3
 
       traces = get_all_traces
-      assert_equal 21, refined_trace_count(traces)
-      assert valid_edges?(traces), "Invalid edge in traces"
+      assert_equal 20, refined_trace_count(traces)
+      assert valid_edges?(traces, false), "Invalid edge in traces"
 
       assert_equal 'sidekiq-client',       traces[1]['Layer']
       assert_equal 'entry',                traces[1]['Label']
@@ -87,8 +87,8 @@ unless defined?(JRUBY_VERSION)
       sleep 3
 
       traces = get_all_traces
-      assert_equal 21, refined_trace_count(traces)
-      assert valid_edges?(traces), "Invalid edge in traces"
+      assert_equal 20, refined_trace_count(traces)
+      assert valid_edges?(traces, false), "Invalid edge in traces"
       assert_equal 'sidekiq-client',   traces[1]['Layer']
       assert_equal false,              traces[1].key?('Backtrace')
     end
@@ -105,8 +105,8 @@ unless defined?(JRUBY_VERSION)
       sleep 3
 
       traces = get_all_traces
-      assert_equal 21, refined_trace_count(traces)
-      assert valid_edges?(traces), "Invalid edge in traces"
+      assert_equal 20, refined_trace_count(traces)
+      assert valid_edges?(traces, false), "Invalid edge in traces"
       assert_equal 'sidekiq-client',   traces[1]['Layer']
       assert_equal true,               traces[1].key?('Backtrace')
     end
@@ -123,8 +123,8 @@ unless defined?(JRUBY_VERSION)
       sleep 3
 
       traces = get_all_traces
-      assert_equal 21, refined_trace_count(traces)
-      assert valid_edges?(traces), "Invalid edge in traces"
+      assert_equal 20, refined_trace_count(traces)
+      assert valid_edges?(traces, false), "Invalid edge in traces"
       assert_equal false, traces[1].key?('Args')
     end
 
@@ -140,8 +140,8 @@ unless defined?(JRUBY_VERSION)
       sleep 3
 
       traces = get_all_traces
-      assert_equal 21, refined_trace_count(traces)
-      assert valid_edges?(traces), "Invalid edge in traces"
+      assert_equal 20, refined_trace_count(traces)
+      assert valid_edges?(traces, false), "Invalid edge in traces"
       assert_equal true,         traces[1].key?('Args')
       assert_equal '[1, 2, 3]',  traces[1]['Args']
     end
@@ -160,7 +160,7 @@ unless defined?(JRUBY_VERSION)
       # FIXME: the sidekiq worker is not respecting the AppOpticsAPM::Config[:tracing_mode] = 'never' setting
       # ____ instead of no traces we are getting 17, that is 4 less than we would get with tracing
       # assert_equal 0, traces.count
-      assert_equal 17, refined_trace_count(traces)
+      assert_equal 16, refined_trace_count(traces)
     end
   end
 end

--- a/test/instrumentation/sidekiq-worker_test.rb
+++ b/test/instrumentation/sidekiq-worker_test.rb
@@ -39,7 +39,7 @@ unless defined?(JRUBY_VERSION)
       sleep 5
 
       traces = get_all_traces
-      assert_equal 17, traces.count, "Trace count"
+      assert_equal 16, traces.count, "Trace count"
       validate_outer_layers(traces, "sidekiq-worker")
       assert valid_edges?(traces), "Invalid edge in traces"
 
@@ -66,7 +66,7 @@ unless defined?(JRUBY_VERSION)
       assert_equal false,                 traces[0].key?('Backtrace')
       assert_equal "net-http",            traces[4]['Layer']
       assert_equal "entry",               traces[4]['Label']
-      assert_equal "memcache",            traces[15]['Layer']
+      assert_equal "memcache",            traces[14]['Layer']
     end
 
     def test_jobs_with_errors
@@ -124,7 +124,7 @@ unless defined?(JRUBY_VERSION)
       sleep 5
 
       traces = get_all_traces
-      assert_equal 17, traces.count, "Trace count"
+      assert_equal 16, traces.count, "Trace count"
       assert valid_edges?(traces), "Invalid edge in traces"
       assert_equal 'sidekiq-worker',   traces[0]['Layer']
       assert_equal false,              traces[0].key?('Backtrace')
@@ -164,7 +164,7 @@ unless defined?(JRUBY_VERSION)
       sleep 5
 
       traces = get_all_traces
-      assert_equal 17, traces.count, "Trace count"
+      assert_equal 16, traces.count, "Trace count"
       assert valid_edges?(traces), "Invalid edge in traces"
       assert_equal false, traces[0].key?('Args')
     end
@@ -179,7 +179,7 @@ unless defined?(JRUBY_VERSION)
       sleep 5
 
       traces = get_all_traces
-      assert_equal 17, traces.count, "Trace count"
+      assert_equal 16, traces.count, "Trace count"
       assert valid_edges?(traces), "Invalid edge in traces"
       assert_equal true,         traces[0].key?('Args')
       assert_equal '[1, 2, 3]',  traces[0]['Args']

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -32,7 +32,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 7
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -41,14 +41,35 @@ describe "Typhoeus" do
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
     traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'info'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Spec'].must_equal 'rsc'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
     traces[5]['HTTPMethod'].must_equal 'GET'
     traces[5]['HTTPStatus'].must_equal 200
+  end
 
-    traces[6]['Layer'].must_equal 'typhoeus'
-    traces[6]['Label'].must_equal 'exit'
+  it 'should trace a typhoeus request to an uninstrumented app' do
+    AppOpticsAPM::API.start_trace('typhoeus_test') do
+      Typhoeus.get("http://127.0.0.1:8110/?blah=1")
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 4
+
+    valid_edges?(traces).must_equal true
+    validate_outer_layers(traces, 'typhoeus_test')
+
+    traces[1]['Layer'].must_equal 'typhoeus'
+    traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
+
+    traces[2]['Layer'].must_equal 'typhoeus'
+    traces[2]['Label'].must_equal 'exit'
+    traces[2]['Spec'].must_equal 'rsc'
+    traces[2]['IsService'].must_equal 1
+    traces[2]['RemoteURL'].must_equal 'http://127.0.0.1:8110/?blah=1'
+    traces[2]['HTTPMethod'].must_equal 'GET'
+    traces[2]['HTTPStatus'].must_equal 200
   end
 
   it 'should trace a typhoeus POST request' do
@@ -58,7 +79,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 7
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -67,24 +88,22 @@ describe "Typhoeus" do
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
     traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'info'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Spec'].must_equal 'rsc'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteURL'].casecmp('http://127.0.0.1:8101/').must_equal 0
     traces[5]['HTTPMethod'].must_equal 'POST'
     traces[5]['HTTPStatus'].must_equal 200
-
-    traces[6]['Layer'].must_equal 'typhoeus'
-    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace a typhoeus PUT request' do
     AppOpticsAPM::API.start_trace('typhoeus_test') do
       Typhoeus.put("http://127.0.0.1:8101/",
-                    :body => { :key => "appoptics-ruby-fake", :content => "appoptics-ruby repo test suite"})
+                   :body => { :key => "appoptics-ruby-fake", :content => "appoptics-ruby repo test suite"})
     end
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 7
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -93,14 +112,12 @@ describe "Typhoeus" do
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
     traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'info'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Spec'].must_equal 'rsc'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
     traces[5]['HTTPMethod'].must_equal 'PUT'
     traces[5]['HTTPStatus'].must_equal 200
-
-    traces[6]['Layer'].must_equal 'typhoeus'
-    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace a typhoeus DELETE request' do
@@ -109,7 +126,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 7
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -118,14 +135,12 @@ describe "Typhoeus" do
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
     traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'info'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Spec'].must_equal 'rsc'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
     traces[5]['HTTPMethod'].must_equal 'DELETE'
     traces[5]['HTTPStatus'].must_equal 200
-
-    traces[6]['Layer'].must_equal 'typhoeus'
-    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace a typhoeus HEAD request' do
@@ -134,7 +149,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 7
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -143,14 +158,12 @@ describe "Typhoeus" do
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
     traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'info'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Spec'].must_equal 'rsc'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
     traces[5]['HTTPMethod'].must_equal 'HEAD'
     traces[5]['HTTPStatus'].must_equal 200
-
-    traces[6]['Layer'].must_equal 'typhoeus'
-    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace a typhoeus GET request to an instr\'d app' do
@@ -159,7 +172,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 7
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -168,14 +181,12 @@ describe "Typhoeus" do
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
     traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'info'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Spec'].must_equal 'rsc'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteURL'].casecmp('http://127.0.0.1:8101/').must_equal 0
     traces[5]['HTTPMethod'].must_equal 'GET'
     traces[5]['HTTPStatus'].must_equal 200
-
-    traces[6]['Layer'].must_equal 'typhoeus'
-    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace a typhoeus GET request with DNS error' do
@@ -184,7 +195,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 6
+    traces.count.must_equal 5
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -200,17 +211,12 @@ describe "Typhoeus" do
     traces.select { |trace| trace['Label'] == 'error' }.count.must_equal 1
 
     traces[3]['Layer'].must_equal 'typhoeus'
-    traces[3]['Label'].must_equal 'info'
+    traces[3]['Label'].must_equal 'exit'
+    traces[3]['Spec'].must_equal 'rsc'
     traces[3]['IsService'].must_equal 1
     traces[3]['RemoteURL'].casecmp('http://thisdomaindoesntexisthopefully.asdf/products/appoptics_apm/').must_equal 0
     traces[3]['HTTPMethod'].must_equal 'GET'
     traces[3]['HTTPStatus'].must_equal 0
-
-    traces[3]['Layer'].must_equal 'typhoeus'
-    traces[3]['Label'].must_equal 'info'
-
-    traces[4]['Layer'].must_equal 'typhoeus'
-    traces[4]['Label'].must_equal 'exit'
   end
 
   it 'should trace parallel typhoeus requests' do
@@ -231,7 +237,7 @@ describe "Typhoeus" do
     traces = get_all_traces
     traces.count.must_equal 13
 
-    valid_edges?(traces).must_equal true
+    valid_edges?(traces, false).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
 
     traces[1]['Layer'].must_equal 'typhoeus_hydra'
@@ -250,7 +256,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 7
     traces[5]['RemoteURL'].casecmp('http://127.0.0.1:8101/?blah=1').must_equal 0
   end
 
@@ -262,7 +268,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 7
     traces[5]['RemoteURL'].casecmp('http://127.0.0.1:8101/').must_equal 0
   end
 
@@ -274,7 +280,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 7
     layer_has_key(traces, 'typhoeus', 'Backtrace')
   end
 
@@ -286,7 +292,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 7
     layer_doesnt_have_key(traces, 'typhoeus', 'Backtrace')
   end
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -39,7 +39,9 @@ puts "\n\033[1m=== TEST RUN: #{RUBY_VERSION} #{File.basename(ENV['BUNDLE_GEMFILE
 
 ENV['RACK_ENV'] = 'test'
 
-ENV['APPOPTICS_GEM_TEST'] = 'true' # comment this out to send traces to the collector configured in `env`
+ # comment this out to send traces to the collector configured in `env`
+ # make sure to set APPOPTICS_SERVICE_KEY
+ENV['APPOPTICS_GEM_TEST'] = 'true'
 
 # ENV['APPOPTICS_GEM_VERBOSE'] = 'true'
 
@@ -190,10 +192,10 @@ end
 # since we won't have those remote traces to validate
 # against.
 #
-# The param synchronous can be set to false if there are async traces
+# The param connected can be set to false if there are undisconnected traces
 #
-def valid_edges?(traces, synchronous = true)
-  return true unless traces.is_a?(Array) # so that in case the traces are sent to the collector, tests will fail but not barf
+def valid_edges?(traces, connected = true)
+  return true unless traces.is_a?(Array) && traces.count > 1 # so that in case the traces are sent to the collector, tests will fail but not barf
   traces[1..-1].reverse.each do  |t|
     if t.key?("Edge")
       unless has_edge?(t["Edge"], traces)
@@ -201,7 +203,7 @@ def valid_edges?(traces, synchronous = true)
       end
     end
   end
-  if synchronous
+  if connected
     return traces.map{ |tr| tr['Edge'] }.uniq.size == traces.size
   end
   true

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -190,7 +190,9 @@ end
 # since we won't have those remote traces to validate
 # against.
 #
-def valid_edges?(traces)
+# The param synchronous can be set to false if there are async traces
+#
+def valid_edges?(traces, synchronous = true)
   return true unless traces.is_a?(Array) # so that in case the traces are sent to the collector, tests will fail but not barf
   traces[1..-1].reverse.each do  |t|
     if t.key?("Edge")
@@ -198,6 +200,9 @@ def valid_edges?(traces)
         return false
       end
     end
+  end
+  if synchronous
+    return traces.map{ |tr| tr['Edge'] }.uniq.size == traces.size
   end
   true
 end

--- a/test/mocked/faraday_mocked_test.rb
+++ b/test/mocked/faraday_mocked_test.rb
@@ -32,7 +32,7 @@ if !defined?(JRUBY_VERSION)
       end
 
       assert_requested :get, "http://127.0.0.1:8101/", times: 1
-      assert_requested :get, "http://127.0.0.1:8101/", headers: {'X-Trace'=>/^2B[0-9,A-F]*01$/}, times: 1
+      refute_requested :get, "http://127.0.0.1:8101/", headers: {'X-Trace'=>/^2B[0-9,A-F]*01$/}, times: 1
       refute AppOpticsAPM::Context.isValid
     end
 
@@ -50,8 +50,8 @@ if !defined?(JRUBY_VERSION)
       end
 
       assert_requested :get, "http://127.0.0.12:8101/", times: 1
-      assert_requested :get, "http://127.0.0.12:8101/", headers: {'X-Trace'=>/^2B[0-9,A-F]*00$/}, times: 1
-      assert_not_requested :get, "http://127.0.0.12:8101/", headers: {'X-Trace'=>/^2B0*$/}
+      refute_requested :get, "http://127.0.0.12:8101/", headers: {'X-Trace'=>/^2B[0-9,A-F]*00$/}, times: 1
+      refute_requested :get, "http://127.0.0.12:8101/", headers: {'X-Trace'=>/^2B0*$/}
       refute AppOpticsAPM::Context.isValid
     end
 
@@ -64,7 +64,7 @@ if !defined?(JRUBY_VERSION)
       conn.get
 
       assert_requested :get, "http://127.0.0.3:8101/", times: 1
-      assert_not_requested :get, "http://127.0.0.3:8101/", headers: {'X-Trace'=>/^.*$/}
+      refute_requested :get, "http://127.0.0.3:8101/", headers: {'X-Trace'=>/^.*$/}
     end
 
     def test_blacklisted
@@ -81,9 +81,74 @@ if !defined?(JRUBY_VERSION)
       end
 
       assert_requested :get, "http://127.0.0.4:8101/", times: 1
-      assert_not_requested :get, "http://127.0.0.4:8101/", headers: {'X-Trace'=>/^.*$/}
+      refute_requested :get, "http://127.0.0.4:8101/", headers: {'X-Trace'=>/^.*$/}
       refute AppOpticsAPM::Context.isValid
     end
 
+    ##### with uninstrumented middleware #####
+
+    def test_tracing_sampling_patron
+      stub_request(:get, "http://127.0.0.1:8101/")
+
+      AppOpticsAPM::API.start_trace('faraday_test') do
+        conn = Faraday.new(:url => 'http://127.0.0.1:8101') do |faraday|
+          faraday.adapter :patron # use an uninstrumented middleware
+        end
+        conn.get
+      end
+
+      assert_requested :get, "http://127.0.0.1:8101/", times: 1
+      assert_requested :get, "http://127.0.0.1:8101/", headers: {'X-Trace'=>/^2B[0-9,A-F]*01$/}, times: 1
+      refute AppOpticsAPM::Context.isValid
+    end
+
+    def test_tracing_not_sampling_patron
+      stub_request(:get, "http://127.0.0.12:8101/")
+
+      AppOpticsAPM.config_lock.synchronize do
+        AppOpticsAPM::Config[:sample_rate] = 0
+        AppOpticsAPM::API.start_trace('faraday_test') do
+          conn = Faraday.new(:url => 'http://127.0.0.12:8101') do |faraday|
+            faraday.adapter :patron # use an uninstrumented middleware
+          end
+          conn.get
+        end
+      end
+
+      assert_requested :get, "http://127.0.0.12:8101/", times: 1
+      assert_requested :get, "http://127.0.0.12:8101/", headers: {'X-Trace'=>/^2B[0-9,A-F]*00$/}, times: 1
+      assert_not_requested :get, "http://127.0.0.12:8101/", headers: {'X-Trace'=>/^2B0*$/}
+      refute AppOpticsAPM::Context.isValid
+    end
+
+    def test_no_xtrace_patron
+      stub_request(:get, "http://127.0.0.3:8101/")
+
+      conn = Faraday.new(:url => 'http://127.0.0.3:8101') do |faraday|
+        faraday.adapter :patron # use an uninstrumented middleware
+      end
+      conn.get
+
+      assert_requested :get, "http://127.0.0.3:8101/", times: 1
+      assert_not_requested :get, "http://127.0.0.3:8101/", headers: {'X-Trace'=>/^.*$/}
+    end
+
+    def test_blacklisted_patron
+      stub_request(:get, "http://127.0.0.4:8101/")
+
+      AppOpticsAPM.config_lock.synchronize do
+        AppOpticsAPM::Config.blacklist << '127.0.0.4'
+        AppOpticsAPM::API.start_trace('faraday_test') do
+          conn = Faraday.new(:url => 'http://127.0.0.4:8101') do |faraday|
+            faraday.adapter :patron # use an uninstrumented middleware
+          end
+          conn.get
+        end
+      end
+
+      assert_requested :get, "http://127.0.0.4:8101/", times: 1
+      assert_not_requested :get, "http://127.0.0.4:8101/", headers: {'X-Trace'=>/^.*$/}
+      refute AppOpticsAPM::Context.isValid
+    end
   end
 end

--- a/test/queues/delayed_job-client_test.rb
+++ b/test/queues/delayed_job-client_test.rb
@@ -33,7 +33,7 @@ class DelayedJobClientTest < Minitest::Test
     sleep 15
 
     traces = get_all_traces
-    assert valid_edges?(traces), "Invalid edge in traces"
+    assert valid_edges?(traces, false), "Invalid edge in traces" # we don't connect traces from clients and workers
 
     assert_equal 'dj_delay',              traces[0]['Layer']
     assert_equal 'entry',                 traces[0]['Label']
@@ -69,7 +69,7 @@ class DelayedJobClientTest < Minitest::Test
     end
 
     traces = get_all_traces
-    assert valid_edges?(traces), "Invalid edge in traces"
+    assert valid_edges?(traces, false), "Invalid edge in traces" # we don't connect traces from clients and workers
 
     assert_equal 'delayed_job-client',    traces[1]['Layer']
     assert_equal 'entry',                 traces[1]['Label']
@@ -87,7 +87,7 @@ class DelayedJobClientTest < Minitest::Test
     end
 
     traces = get_all_traces
-    assert valid_edges?(traces), "Invalid edge in traces"
+    assert valid_edges?(traces, false), "Invalid edge in traces" # we don't connect traces from clients and workers
 
     assert_equal 'delayed_job-client',    traces[1]['Layer']
     assert_equal 'entry',                 traces[1]['Label']

--- a/test/run_tests/docker-compose.yml
+++ b/test/run_tests/docker-compose.yml
@@ -26,6 +26,8 @@ services:
      links:
        - wait
      environment:
+       - APPOPTICS_SERVICE_KEY=${APPOPTICS_SERVICE_KEY}
+       - APPOPTICS_COLLECTOR=${APPOPTICS_COLLECTOR}
        - APPOPTICS_RABBITMQ_SERVER=rabbitmq
        - DOCKER_MYSQL_PASS=admin
        - MYSQL_ALLOW_EMPTY_PASSWORD=yes

--- a/test/servers/delayed_job.rb
+++ b/test/servers/delayed_job.rb
@@ -8,6 +8,8 @@ require "rails/all"
 require "delayed_job"
 require "action_controller/railtie"
 require 'rack/handler/puma'
+require 'appoptics_apm/test'
+
 require File.expand_path(File.dirname(__FILE__) + '/../models/widget')
 
 AppOpticsAPM.logger.level = Logger::DEBUG

--- a/test/servers/rackapp_8101.rb
+++ b/test/servers/rackapp_8101.rb
@@ -24,6 +24,22 @@ Thread.new do
   Rack::Handler::Puma.run(app, {:Host => '127.0.0.1', :Port => 8101})
 end
 
+AppOpticsAPM.logger.info "[appoptics_apm/info] Starting UNINSTRUMENTED background utility rack app on localhost:8110."
+
+Thread.new do
+  app = Rack::Builder.new {
+    map "/" do
+      run Proc.new { [200, {"Content-Type" => "text/html"}, ['Hello AppOpticsAPM!']] }
+    end
+
+    map "/redirectme" do
+      run Proc.new { [301, {"Location" => "/", "Content-Type" => "text/html"}, ['']] }
+    end
+  }
+
+  Rack::Handler::Puma.run(app, {:Host => '127.0.0.1', :Port => 8110})
+end
+
 # Allow Thin to boot.
 sleep(2)
 


### PR DESCRIPTION
Faraday has different options for the adapter it uses to make calls to a remote service.
I the adapter is instrumented it will take care of creating the span with the 'rsc' Spec and required kvs. If the is not instrumented then Faraday needs to create the 'rsc' span.

The work in this PR includes:
- Fix faraday to detect if the adapter is instrumented and connect edges correctly in that case.
- Update remote call KVs to reflect current spec
- add tests and update tests

[AO-10414 Move.com broken traces](https://swicloud.atlassian.net/browse/AO-10414)[AO-10487 Ruby: Outbound instrumentations don't connect Edges correctly](https://swicloud.atlassian.net/browse/AO-10487)