### PR TITLE
Double colon clean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ env:
   - DBTYPE=mysql
 
 rvm:
-#  - 2.5.3
+  - 2.5.3
   - 2.4.5
-#  - 2.3.8
+  - 2.3.8
 #  - jruby-9.0.5.0
-#  - ruby-head
+  - ruby-head
 
 gemfile:
   - gemfiles/libraries.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ env:
   - DBTYPE=mysql
 
 rvm:
-  - 2.5.3
+#  - 2.5.3
   - 2.4.5
-  - 2.3.8
+#  - 2.3.8
 #  - jruby-9.0.5.0
-  - ruby-head
+#  - ruby-head
 
 gemfile:
   - gemfiles/libraries.gemfile

--- a/examples/carrying_context.rb
+++ b/examples/carrying_context.rb
@@ -19,7 +19,7 @@
 #
 # For example, when a web request comes into a stack, a tracing
 # context is established using `AppOpticsAPM::API.log_start` as the request
-# enters through the rack middleware via `::AppOpticsAPM::Rack`.
+# enters through the rack middleware via `AppOpticsAPM::Rack`.
 #
 # That tracing context is then continued using `AppOpticsAPM::API.trace` or
 # `AppOpticsAPM::API.log_entry` for each subsequent layer such as Rails,

--- a/gemfiles/frameworks.gemfile
+++ b/gemfiles/frameworks.gemfile
@@ -17,7 +17,7 @@ else
   gem 'sinatra'
 end
 
-gem "grape"
+gem 'grape', '< 1.2.0' # temporarily pin grape version because 1.2.0 introduced a breaking change
 
 if defined?(JRUBY_VERSION)
   # Limit padrino gem under JRuby as version 0.13.0 throws

--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -36,7 +36,7 @@ gem 'excon'
 gem 'faraday'
 gem 'httpclient'
 gem 'memcached'
-gem 'patron' # not instrumented, to test non-instrumented faraday adapter
+gem 'patron' # not instrumented, needed to test a non-instrumented faraday adapter
 gem 'redis'
 gem 'resque' unless defined?(JRUBY_VERSION)
 gem 'sequel'

--- a/lib/appoptics_apm/api/logging.rb
+++ b/lib/appoptics_apm/api/logging.rb
@@ -102,7 +102,7 @@ module AppOpticsAPM
       #
       # Returns an xtrace metadata string if we are tracing
       def log_start(layer, xtrace = nil, opts = {})
-        return if !AppOpticsAPM.loaded || (opts.key?(:URL) && ::AppOpticsAPM::Util.static_asset?(opts[:URL]))
+        return if !AppOpticsAPM.loaded || (opts.key?(:URL) && AppOpticsAPM::Util.static_asset?(opts[:URL]))
 
         #--
         # Is the below necessary? Only on JRuby? Could there be an existing context but not x-trace header?

--- a/lib/appoptics_apm/api/profiling.rb
+++ b/lib/appoptics_apm/api/profiling.rb
@@ -51,6 +51,7 @@ module AppOpticsAPM
             exit_kvs[:Language] = :ruby
             exit_kvs[:ProfileName] = report_kvs[:ProfileName]
 
+            report_kvs.delete(:Backtrace)
             AppOpticsAPM::API.log(nil, :profile_exit, exit_kvs)
           end
         end

--- a/lib/appoptics_apm/api/profiling.rb
+++ b/lib/appoptics_apm/api/profiling.rb
@@ -51,7 +51,6 @@ module AppOpticsAPM
             exit_kvs[:Language] = :ruby
             exit_kvs[:ProfileName] = report_kvs[:ProfileName]
 
-            report_kvs.delete(:Backtrace)
             AppOpticsAPM::API.log(nil, :profile_exit, exit_kvs)
           end
         end

--- a/lib/appoptics_apm/api/profiling.rb
+++ b/lib/appoptics_apm/api/profiling.rb
@@ -124,10 +124,10 @@ module AppOpticsAPM
 
         source_location = []
         if instance_method
-          ::AppOpticsAPM::Util.send_include(klass, ::AppOpticsAPM::MethodProfiling)
+          AppOpticsAPM::Util.send_include(klass, AppOpticsAPM::MethodProfiling)
           source_location = klass.instance_method(method).source_location
         elsif class_method
-          ::AppOpticsAPM::Util.send_extend(klass, ::AppOpticsAPM::MethodProfiling)
+          AppOpticsAPM::Util.send_extend(klass, AppOpticsAPM::MethodProfiling)
           source_location = klass.method(method).source_location
         end
 

--- a/lib/appoptics_apm/api/tracing.rb
+++ b/lib/appoptics_apm/api/tracing.rb
@@ -48,7 +48,6 @@ module AppOpticsAPM
         [start_trace_with_target(span, xtrace, target, opts) { yield }, target['X-Trace']]
       end
 
-
     end
   end
 end

--- a/lib/appoptics_apm/base.rb
+++ b/lib/appoptics_apm/base.rb
@@ -33,7 +33,7 @@ TRACE_FILE = '/tmp/appoptics_traces.bson'.freeze
 # Current variations as of 2014-09-10 are a c-extension, JRuby (using AppOpticsAPM Java
 # instrumentation) and a Heroku c-extension (with embedded tracelyzer)
 module AppOpticsAPMBase
-  extend ::AppOpticsAPM::ThreadLocal
+  extend AppOpticsAPM::ThreadLocal
 
   attr_accessor :reporter
   attr_accessor :loaded

--- a/lib/appoptics_apm/config.rb
+++ b/lib/appoptics_apm/config.rb
@@ -15,9 +15,9 @@ module AppOpticsAPM
                          :active_record, :bunnyclient, :bunnyconsumer, :cassandra, :curb,
                          :dalli, :delayed_jobclient, :delayed_jobworker,
                          :em_http_request, :excon, :faraday, :grpc_client, :grape,
-                         :httpclient, :nethttp, :memcached, :mongo, :moped, :rack, :redis,
+                         :httpclient, :memcached, :mongo, :moped, :nethttp, :padrino, :rack, :redis,
                          :resqueclient, :resqueworker, :rest_client,
-                         :sequel, :sidekiqclient, :sidekiqworker, :typhoeus]
+                         :sequel, :sidekiqclient, :sidekiqworker, :sinatra, :typhoeus]
 
     # Subgrouping of instrumentation
     @@http_clients = [:curb, :excon, :em_http_request, :faraday, :httpclient, :nethttp, :rest_client, :typhoeus]

--- a/lib/appoptics_apm/frameworks/grape.rb
+++ b/lib/appoptics_apm/frameworks/grape.rb
@@ -33,6 +33,7 @@ module AppOpticsAPM
         else
           report_kvs[:Action] = args.empty? ? env['PATH_INFO'] : args[0]['PATH_INFO']
         end
+        report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:grape][:collect_backtraces]
 
         env['appoptics_apm.controller'] = report_kvs[:Controller]
         env['appoptics_apm.action']     = report_kvs[:Action]
@@ -62,7 +63,7 @@ module AppOpticsAPM
             exception = GrapeError.new(error[:message] ? error[:message] : "No message given.")
             exception.set_backtrace(::AppOpticsAPM::API.backtrace)
 
-            ::AppOpticsAPM::API.log_exception('rack', exception )
+            ::AppOpticsAPM::API.log_exception('rack', exception)
 
             # Since calls to error() are handled similar to abort in Grape.  We
             # manually log the rack exit here since the original code won't

--- a/lib/appoptics_apm/frameworks/grape.rb
+++ b/lib/appoptics_apm/frameworks/grape.rb
@@ -7,19 +7,19 @@ module AppOpticsAPM
   module Grape
     module API
       def self.extended(klass)
-        ::AppOpticsAPM::Util.class_method_alias(klass, :inherited, ::Grape::API)
+        AppOpticsAPM::Util.class_method_alias(klass, :inherited, ::Grape::API)
       end
 
       def inherited_with_appoptics(subclass)
         inherited_without_appoptics(subclass)
 
-        subclass.use ::AppOpticsAPM::Rack
+        subclass.use AppOpticsAPM::Rack
       end
     end
 
     module Endpoint
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :run, ::Grape::Endpoint)
+        AppOpticsAPM::Util.method_alias(klass, :run, ::Grape::Endpoint)
       end
 
       def run_with_appoptics(*args)
@@ -38,18 +38,18 @@ module AppOpticsAPM
         env['appoptics_apm.controller'] = report_kvs[:Controller]
         env['appoptics_apm.action']     = report_kvs[:Action]
 
-        ::AppOpticsAPM::API.log_entry('grape', report_kvs)
+        AppOpticsAPM::API.log_entry('grape', report_kvs)
 
         run_without_appoptics(*args)
       ensure
-        ::AppOpticsAPM::API.log_exit('grape')
+        AppOpticsAPM::API.log_exit('grape')
       end
     end
 
     module Middleware
       module Error
         def self.included(klass)
-          ::AppOpticsAPM::Util.method_alias(klass, :error_response, ::Grape::Middleware::Error)
+          AppOpticsAPM::Util.method_alias(klass, :error_response, ::Grape::Middleware::Error)
         end
 
         def error_response_with_appoptics(error = {})
@@ -61,9 +61,9 @@ module AppOpticsAPM
 
             # Since Grape uses throw/catch and not Exceptions, we have to create an exception here
             exception = GrapeError.new(error[:message] ? error[:message] : "No message given.")
-            exception.set_backtrace(::AppOpticsAPM::API.backtrace)
+            exception.set_backtrace(AppOpticsAPM::API.backtrace)
 
-            ::AppOpticsAPM::API.log_exception('rack', exception)
+            AppOpticsAPM::API.log_exception('rack', exception)
 
             # Since calls to error() are handled similar to abort in Grape.  We
             # manually log the rack exit here since the original code won't
@@ -84,14 +84,14 @@ module AppOpticsAPM
   end
 end
 
-if AppOpticsAPM::Config[:grape][:enabled] && defined?(::Grape)
+if AppOpticsAPM::Config[:grape][:enabled] && defined?(Grape)
   require 'appoptics_apm/inst/rack'
 
   AppOpticsAPM.logger.info "[appoptics_apm/loading] Instrumenting Grape" if AppOpticsAPM::Config[:verbose]
 
   AppOpticsAPM::Inst.load_instrumentation
 
-  ::AppOpticsAPM::Util.send_extend(::Grape::API,               ::AppOpticsAPM::Grape::API)
-  ::AppOpticsAPM::Util.send_include(::Grape::Endpoint,          ::AppOpticsAPM::Grape::Endpoint)
-  ::AppOpticsAPM::Util.send_include(::Grape::Middleware::Error, ::AppOpticsAPM::Grape::Middleware::Error)
+  AppOpticsAPM::Util.send_extend(Grape::API,                AppOpticsAPM::Grape::API)
+  AppOpticsAPM::Util.send_include(Grape::Endpoint,          AppOpticsAPM::Grape::Endpoint)
+  AppOpticsAPM::Util.send_include(Grape::Middleware::Error, AppOpticsAPM::Grape::Middleware::Error)
 end

--- a/lib/appoptics_apm/frameworks/padrino.rb
+++ b/lib/appoptics_apm/frameworks/padrino.rb
@@ -91,8 +91,6 @@ if defined?(::Padrino)
   # to how Padrino is a superset of Sinatra itself.
   ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting Padrino' if AppOpticsAPM::Config[:verbose]
 
-  require 'appoptics_apm/frameworks/padrino/templates'
-
   Padrino.after_load do
     ::AppOpticsAPM.logger = ::Padrino.logger if ::Padrino.respond_to?(:logger)
     ::AppOpticsAPM::Inst.load_instrumentation

--- a/lib/appoptics_apm/frameworks/padrino.rb
+++ b/lib/appoptics_apm/frameworks/padrino.rb
@@ -5,12 +5,12 @@ module AppOpticsAPM
   module PadrinoInst
     module Routing
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :dispatch!, ::Padrino::Routing)
+        AppOpticsAPM::Util.method_alias(klass, :dispatch!, ::Padrino::Routing)
       end
 
       def dispatch_with_appoptics
 
-        ::AppOpticsAPM::API.log_entry('padrino', {})
+        AppOpticsAPM::API.log_entry('padrino', {})
         report_kvs = {}
 
         result = dispatch_without_appoptics
@@ -24,17 +24,17 @@ module AppOpticsAPM
 
         result
       rescue => e
-        ::AppOpticsAPM::API.log_exception('padrino', e)
+        AppOpticsAPM::API.log_exception('padrino', e)
         raise e
       ensure
         report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:padrino][:collect_backtraces]
-        ::AppOpticsAPM::API.log_exit('padrino', report_kvs)
+        AppOpticsAPM::API.log_exit('padrino', report_kvs)
       end
     end
 
     module Rendering
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :render, ::Padrino::Rendering)
+        AppOpticsAPM::Util.method_alias(klass, :render, ::Padrino::Rendering)
       end
 
       # TODO add test coverage, currently there are no tests for this
@@ -59,8 +59,8 @@ module AppOpticsAPM
               report_kvs[:File]         = __FILE__
               report_kvs[:LineNumber]   = __LINE__
             rescue StandardError => e
-              ::AppOpticsAPM.logger.debug "[appoptics_apm/padrino] #{e.message}"
-              ::AppOpticsAPM.logger.debug e.backtrace.join(', ')
+              AppOpticsAPM.logger.debug "[appoptics_apm/padrino] #{e.message}"
+              AppOpticsAPM.logger.debug e.backtrace.join(', ')
             end
 
             AppOpticsAPM::API.profile(report_kvs[:template], report_kvs, false) do
@@ -71,13 +71,13 @@ module AppOpticsAPM
             # back on exit (a limitation of the AppOpticsAPM::API.trace
             # block method) This removes the need for an info
             # event to send additonal KVs
-            ::AppOpticsAPM::API.log_entry(:render, {}, :render)
+            AppOpticsAPM::API.log_entry(:render, {}, :render)
 
             begin
               render_without_appoptics(engine, data, options, locals, &block)
             ensure
               report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:padrino][:collect_backtraces]
-              ::AppOpticsAPM::API.log_exit(:render, report_kvs)
+              AppOpticsAPM::API.log_exit(:render, report_kvs)
             end
           end
         else
@@ -88,18 +88,18 @@ module AppOpticsAPM
   end
 end
 
-if defined?(::Padrino) && AppopticsAPM::Config[:padrino][:enabled]
+if defined?(Padrino) && AppopticsAPM::Config[:padrino][:enabled]
   # This instrumentation is a superset of the Sinatra instrumentation similar
   # to how Padrino is a superset of Sinatra itself.
-  ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting Padrino' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting Padrino' if AppOpticsAPM::Config[:verbose]
 
   Padrino.after_load do
-    ::AppOpticsAPM.logger = ::Padrino.logger if ::Padrino.respond_to?(:logger)
-    ::AppOpticsAPM::Inst.load_instrumentation
+    AppOpticsAPM.logger = Padrino.logger if Padrino.respond_to?(:logger)
+    AppOpticsAPM::Inst.load_instrumentation
 
-    ::AppOpticsAPM::Util.send_include(::Padrino::Routing::InstanceMethods, ::AppOpticsAPM::PadrinoInst::Routing)
-    if defined?(::Padrino::Rendering)
-      ::AppOpticsAPM::Util.send_include(::Padrino::Rendering::InstanceMethods, ::AppOpticsAPM::PadrinoInst::Rendering)
+    AppOpticsAPM::Util.send_include(Padrino::Routing::InstanceMethods, AppOpticsAPM::PadrinoInst::Routing)
+    if defined?(Padrino::Rendering)
+      AppOpticsAPM::Util.send_include(Padrino::Rendering::InstanceMethods, AppOpticsAPM::PadrinoInst::Rendering)
     end
 
     # Report __Init after fork when in Heroku

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller.rb
@@ -88,7 +88,7 @@ if defined?(ActionController::Base) && AppOpticsAPM::Config[:action_controller][
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting actioncontroller' if AppOpticsAPM::Config[:verbose]
   require "appoptics_apm/frameworks/rails/inst/action_controller#{Rails::VERSION::MAJOR}"
   if Rails::VERSION::MAJOR >= 5
-    ::ActionController::Base.send(:prepend, AppOpticsAPM::Inst::ActionController)
+    ActionController::Base.send(:prepend, ::AppOpticsAPM::Inst::ActionController)
   else
     AppOpticsAPM::Util.send_include(::ActionController::Base, AppOpticsAPM::Inst::ActionController)
   end
@@ -98,7 +98,7 @@ end
 if defined?(ActionController::API) && AppOpticsAPM::Config[:action_controller_api][:enabled]
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting actioncontroller api' if AppOpticsAPM::Config[:verbose]
   require "appoptics_apm/frameworks/rails/inst/action_controller_api"
-  ::ActionController::API.send(:prepend, AppOpticsAPM::Inst::ActionControllerAPI)
+  ActionController::API.send(:prepend, ::AppOpticsAPM::Inst::ActionControllerAPI)
 end
 
 # vim:set expandtab:tabstop=2

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller.rb
@@ -88,9 +88,9 @@ if defined?(ActionController::Base) && AppOpticsAPM::Config[:action_controller][
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting actioncontroller' if AppOpticsAPM::Config[:verbose]
   require "appoptics_apm/frameworks/rails/inst/action_controller#{Rails::VERSION::MAJOR}"
   if Rails::VERSION::MAJOR >= 5
-    ::ActionController::Base.send(:prepend, ::AppOpticsAPM::Inst::ActionController)
+    ::ActionController::Base.send(:prepend, AppOpticsAPM::Inst::ActionController)
   else
-    ::AppOpticsAPM::Util.send_include(::ActionController::Base, AppOpticsAPM::Inst::ActionController)
+    AppOpticsAPM::Util.send_include(::ActionController::Base, AppOpticsAPM::Inst::ActionController)
   end
 end
 
@@ -98,7 +98,7 @@ end
 if defined?(ActionController::API) && AppOpticsAPM::Config[:action_controller_api][:enabled]
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting actioncontroller api' if AppOpticsAPM::Config[:verbose]
   require "appoptics_apm/frameworks/rails/inst/action_controller_api"
-  ::ActionController::API.send(:prepend, ::AppOpticsAPM::Inst::ActionControllerAPI)
+  ::ActionController::API.send(:prepend, AppOpticsAPM::Inst::ActionControllerAPI)
 end
 
 # vim:set expandtab:tabstop=2

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller3.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller3.rb
@@ -10,7 +10,7 @@ module AppOpticsAPM
     # to Rails v3
     #
     module ActionController
-      include ::AppOpticsAPM::Inst::RailsBase
+      include AppOpticsAPM::Inst::RailsBase
 
       def self.included(base)
         base.class_eval do

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller3.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller3.rb
@@ -21,12 +21,8 @@ module AppOpticsAPM
       end
 
       def process_with_appoptics(*args)
-        kvs = {
-            :Controller   => self.class.name,
-            :Action       => self.action_name,
-        }
-        request.env['appoptics_apm.controller'] = kvs[:Controller]
-        request.env['appoptics_apm.action'] = kvs[:Action]
+        request.env['appoptics_apm.controller'] = self.class.name
+        request.env['appoptics_apm.action'] = self.action_name
 
         trace('rails') do
           process_without_appoptics(*args)
@@ -48,9 +44,10 @@ module AppOpticsAPM
 
           process_action_without_appoptics(*args)
         rescue Exception
-          kvs[:Status] = 500
-          AppOpticsAPM::API.log(nil, 'info', kvs)
-          raise
+         kvs[:Status] = 500
+         kvs.delete(:Backtrace)
+         AppOpticsAPM::API.log(nil, 'info', kvs)
+         raise
         end
       end
     end

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller4.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller4.rb
@@ -10,7 +10,7 @@ module AppOpticsAPM
     # to Rails v4
     #
     module ActionController
-      include ::AppOpticsAPM::Inst::RailsBase
+      include AppOpticsAPM::Inst::RailsBase
 
       def self.included(base)
         base.class_eval do

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller5.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller5.rb
@@ -10,7 +10,7 @@ module AppOpticsAPM
     # to Rails v5
     #
     module ActionController
-      include ::AppOpticsAPM::Inst::RailsBase
+      include AppOpticsAPM::Inst::RailsBase
 
       def process_action(method_name, *args)
         kvs = {

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller_api.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller_api.rb
@@ -38,7 +38,7 @@ module AppOpticsAPM
       #
       # render
       #
-      # Our render wrapper that calls 'add_logging', which will log if we are tracing
+      # Our render wrapper that calls 'trace', which will log if we are tracing
       #
       def render(*args, &blk)
         trace('actionview') do

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller_api.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller_api.rb
@@ -10,7 +10,7 @@ module AppOpticsAPM
     # to Rails v5.
     #
     module ActionControllerAPI
-      include ::AppOpticsAPM::Inst::RailsBase
+      include AppOpticsAPM::Inst::RailsBase
 
       def process_action(method_name, *args)
         kvs = {

--- a/lib/appoptics_apm/frameworks/rails/inst/connection_adapters/mysql.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/connection_adapters/mysql.rb
@@ -9,31 +9,31 @@ module AppOpticsAPM
           AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting activerecord mysqladapter' if AppOpticsAPM::Config[:verbose]
 
           # ActiveRecord 3.2 and higher
-          if (::ActiveRecord::VERSION::MAJOR == 3 && ::ActiveRecord::VERSION::MINOR >= 2) ||
-              ::ActiveRecord::VERSION::MAJOR == 4
+          if (ActiveRecord::VERSION::MAJOR == 3 && ActiveRecord::VERSION::MINOR >= 2) ||
+              ActiveRecord::VERSION::MAJOR == 4
 
             # AbstractMysqlAdapter
-            AppOpticsAPM::Util.send_include(::ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter,
-                                    ::AppOpticsAPM::Inst::ConnectionAdapters::Utils)
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter, :execute)
+            AppOpticsAPM::Util.send_include(ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter,
+                                    AppOpticsAPM::Inst::ConnectionAdapters::Utils)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter, :execute)
 
             # MysqlAdapter
-            AppOpticsAPM::Util.send_include(::ActiveRecord::ConnectionAdapters::MysqlAdapter,
-                                    ::AppOpticsAPM::Inst::ConnectionAdapters::Utils)
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::MysqlAdapter, :exec_query)
+            AppOpticsAPM::Util.send_include(ActiveRecord::ConnectionAdapters::MysqlAdapter,
+                                    AppOpticsAPM::Inst::ConnectionAdapters::Utils)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::MysqlAdapter, :exec_query)
 
           else
             # ActiveRecord 3.1 and below
 
             # MysqlAdapter
-            AppOpticsAPM::Util.send_include(::ActiveRecord::ConnectionAdapters::MysqlAdapter,
-                                    ::AppOpticsAPM::Inst::ConnectionAdapters::Utils)
+            AppOpticsAPM::Util.send_include(ActiveRecord::ConnectionAdapters::MysqlAdapter,
+                                    AppOpticsAPM::Inst::ConnectionAdapters::Utils)
 
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::MysqlAdapter, :execute)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::MysqlAdapter, :execute)
 
-            if ::ActiveRecord::VERSION::MAJOR == 3 && ::ActiveRecord::VERSION::MINOR == 1
-              AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::MysqlAdapter, :begin_db_transaction)
-              AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::MysqlAdapter, :exec_delete)
+            if ActiveRecord::VERSION::MAJOR == 3 && ActiveRecord::VERSION::MINOR == 1
+              AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::MysqlAdapter, :begin_db_transaction)
+              AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::MysqlAdapter, :exec_delete)
             end
           end
         end

--- a/lib/appoptics_apm/frameworks/rails/inst/connection_adapters/mysql2.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/connection_adapters/mysql2.rb
@@ -8,19 +8,19 @@ module AppOpticsAPM
         def self.mysql2
           AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting activerecord mysql2adapter' if AppOpticsAPM::Config[:verbose]
 
-          AppOpticsAPM::Util.send_include(::ActiveRecord::ConnectionAdapters::Mysql2Adapter,
-                                  ::AppOpticsAPM::Inst::ConnectionAdapters::Utils)
+          AppOpticsAPM::Util.send_include(ActiveRecord::ConnectionAdapters::Mysql2Adapter,
+                                  AppOpticsAPM::Inst::ConnectionAdapters::Utils)
 
-          if (::ActiveRecord::VERSION::MAJOR == 3 && ::ActiveRecord::VERSION::MINOR == 0) ||
-              ::ActiveRecord::VERSION::MAJOR == 2
+          if (ActiveRecord::VERSION::MAJOR == 3 && ActiveRecord::VERSION::MINOR == 0) ||
+              ActiveRecord::VERSION::MAJOR == 2
             # ActiveRecord 3.0 and prior
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::Mysql2Adapter, :execute)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::Mysql2Adapter, :execute)
           else
             # ActiveRecord 3.1 and above
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::Mysql2Adapter, :exec_insert)
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::Mysql2Adapter, :exec_query)
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::Mysql2Adapter, :exec_update)
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::Mysql2Adapter, :exec_delete)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::Mysql2Adapter, :exec_insert)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::Mysql2Adapter, :exec_query)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::Mysql2Adapter, :exec_update)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::Mysql2Adapter, :exec_delete)
           end
         end
       end

--- a/lib/appoptics_apm/frameworks/rails/inst/connection_adapters/postgresql.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/connection_adapters/postgresql.rb
@@ -9,20 +9,20 @@ module AppOpticsAPM
 
           AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting activerecord postgresqladapter' if AppOpticsAPM::Config[:verbose]
 
-          AppOpticsAPM::Util.send_include(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter,
-                                  ::AppOpticsAPM::Inst::ConnectionAdapters::Utils)
+          AppOpticsAPM::Util.send_include(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter,
+                                  AppOpticsAPM::Inst::ConnectionAdapters::Utils)
 
-          if (::ActiveRecord::VERSION::MAJOR == 3 && ::ActiveRecord::VERSION::MINOR > 0) ||
-                ::ActiveRecord::VERSION::MAJOR >= 4
+          if (ActiveRecord::VERSION::MAJOR == 3 && ActiveRecord::VERSION::MINOR > 0) ||
+                ActiveRecord::VERSION::MAJOR >= 4
 
             # ActiveRecord 3.1 and up
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter, :exec_query)
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter, :exec_update)
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter, :exec_delete)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter, :exec_query)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter, :exec_update)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter, :exec_delete)
 
           else
             # ActiveRecord 3.0 and prior
-            AppOpticsAPM::Util.method_alias(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter, :execute)
+            AppOpticsAPM::Util.method_alias(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter, :execute)
           end
         end
       end

--- a/lib/appoptics_apm/frameworks/sinatra.rb
+++ b/lib/appoptics_apm/frameworks/sinatra.rb
@@ -47,12 +47,61 @@ module AppOpticsAPM
       end
       alias_method :oboe_rum_footer, :appoptics_rum_footer
     end
+
+    module Templates
+      def self.included(klass)
+        ::AppOpticsAPM::Util.method_alias(klass, :render, ::Sinatra::Templates)
+      end
+
+      def render_with_appoptics(engine, data, options = {}, locals = {}, &block)
+        if AppOpticsAPM.tracing?
+          report_kvs = {}
+
+          report_kvs[:engine] = engine
+          report_kvs[:template] = data
+
+          if AppOpticsAPM.tracing_layer_op?(:render)
+            # For recursive calls to :render (for sub-partials and layouts),
+            # use method profiling.
+            begin
+              name = data
+              report_kvs[:FunctionName] = :render
+              report_kvs[:Class]        = :Templates
+              report_kvs[:Module]       = :'Sinatra::Templates'
+              report_kvs[:File]         = __FILE__
+              report_kvs[:LineNumber]   = __LINE__
+            rescue StandardError => e
+              ::AppOpticsAPM.logger.debug e.message
+              ::AppOpticsAPM.logger.debug e.backtrace.join(', ')
+            end
+
+            AppOpticsAPM::API.profile(name, report_kvs, false) do
+              render_without_appoptics(engine, data, options, locals, &block)
+            end
+
+          else
+            # Fall back to the raw tracing API so we can pass KVs
+            # back on exit (a limitation of the AppOpticsAPM::API.trace
+            # block method) This removes the need for an info
+            # event to send additonal KVs
+            ::AppOpticsAPM::API.log_entry(:render, {}, :render)
+
+            begin
+              render_without_appoptics(engine, data, options, locals, &block)
+            ensure
+              ::AppOpticsAPM::API.log_exit(:render, report_kvs, :render)
+            end
+          end
+        else
+          render_without_appoptics(engine, data, options, locals, &block)
+        end
+      end
+    end
   end
 end
 
 if defined?(::Sinatra)
   require 'appoptics_apm/inst/rack'
-  require 'appoptics_apm/frameworks/sinatra/templates'
 
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting Sinatra' if AppOpticsAPM::Config[:verbose]
 

--- a/lib/appoptics_apm/frameworks/sinatra.rb
+++ b/lib/appoptics_apm/frameworks/sinatra.rb
@@ -27,6 +27,7 @@ module AppOpticsAPM
         ::AppOpticsAPM::API.log_exception('sinatra', e)
         raise e
       ensure
+        report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:sinatra][:collect_backtraces]
         ::AppOpticsAPM::API.log_exit('sinatra', report_kvs)
       end
 
@@ -89,6 +90,7 @@ module AppOpticsAPM
             begin
               render_without_appoptics(engine, data, options, locals, &block)
             ensure
+              report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:sinatra][:collect_backtraces]
               ::AppOpticsAPM::API.log_exit(:render, report_kvs, :render)
             end
           end
@@ -100,7 +102,7 @@ module AppOpticsAPM
   end
 end
 
-if defined?(::Sinatra)
+if defined?(::Sinatra) && AppopticsAPM::Config[:sinatra][:enabled]
   require 'appoptics_apm/inst/rack'
 
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting Sinatra' if AppOpticsAPM::Config[:verbose]

--- a/lib/appoptics_apm/frameworks/sinatra/templates.rb
+++ b/lib/appoptics_apm/frameworks/sinatra/templates.rb
@@ -3,54 +3,6 @@
 
 module AppOpticsAPM
   module Sinatra
-    module Templates
-      def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :render, ::Sinatra::Templates)
-      end
 
-      def render_with_appoptics(engine, data, options = {}, locals = {}, &block)
-        if AppOpticsAPM.tracing?
-          report_kvs = {}
-
-          report_kvs[:engine] = engine
-          report_kvs[:template] = data
-
-          if AppOpticsAPM.tracing_layer_op?(:render)
-            # For recursive calls to :render (for sub-partials and layouts),
-            # use method profiling.
-            begin
-              name = data
-              report_kvs[:FunctionName] = :render
-              report_kvs[:Class]        = :Templates
-              report_kvs[:Module]       = :'Sinatra::Templates'
-              report_kvs[:File]         = __FILE__
-              report_kvs[:LineNumber]   = __LINE__
-            rescue StandardError => e
-              ::AppOpticsAPM.logger.debug e.message
-              ::AppOpticsAPM.logger.debug e.backtrace.join(', ')
-            end
-
-            AppOpticsAPM::API.profile(name, report_kvs, false) do
-              render_without_appoptics(engine, data, options, locals, &block)
-            end
-
-          else
-            # Fall back to the raw tracing API so we can pass KVs
-            # back on exit (a limitation of the AppOpticsAPM::API.trace
-            # block method) This removes the need for an info
-            # event to send additonal KVs
-            ::AppOpticsAPM::API.log_entry(:render, {}, :render)
-
-            begin
-              render_without_appoptics(engine, data, options, locals, &block)
-            ensure
-              ::AppOpticsAPM::API.log_exit(:render, report_kvs, :render)
-            end
-          end
-        else
-          render_without_appoptics(engine, data, options, locals, &block)
-        end
-      end
-    end
   end
 end

--- a/lib/appoptics_apm/frameworks/sinatra/templates.rb
+++ b/lib/appoptics_apm/frameworks/sinatra/templates.rb
@@ -1,8 +1,0 @@
-# Copyright (c) 2016 SolarWinds, LLC.
-# All rights reserved.
-
-module AppOpticsAPM
-  module Sinatra
-
-  end
-end

--- a/lib/appoptics_apm/inst/bunny-client.rb
+++ b/lib/appoptics_apm/inst/bunny-client.rb
@@ -29,12 +29,12 @@ module AppOpticsAPM
           end
 
           AppOpticsAPM::API.log_entry(:'rabbitmq-client')
-
           delete_without_appoptics(opts)
         rescue => e
           AppOpticsAPM::API.log_exception(:'rabbitmq-client', e)
           raise e
         ensure
+          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:bunnyclient][:collect_backtraces]
           AppOpticsAPM::API.log_exit(:'rabbitmq-client', kvs)
         end
       end
@@ -54,7 +54,6 @@ module AppOpticsAPM
         kvs[:RemoteHost] = @connection.host
         kvs[:RemotePort] = @connection.port.to_i
         kvs[:VirtualHost] = @connection.vhost
-        kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:bunnyclient][:collect_backtraces]
         kvs
       rescue => e
         AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
@@ -92,6 +91,7 @@ module AppOpticsAPM
           AppOpticsAPM::API.log_exception(:'rabbitmq-client', e)
           raise e
         ensure
+          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:bunnyclient][:collect_backtraces]
           AppOpticsAPM::API.log_exit(:'rabbitmq-client', kvs)
         end
       end
@@ -113,6 +113,7 @@ module AppOpticsAPM
           AppOpticsAPM::API.log_exception(:'rabbitmq-client', e)
           raise e
         ensure
+          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:bunnyclient][:collect_backtraces]
           AppOpticsAPM::API.log_exit(:'rabbitmq-client', kvs)
         end
       end
@@ -132,6 +133,7 @@ module AppOpticsAPM
           AppOpticsAPM::API.log_exception(:'rabbitmq-client', e)
           raise e
         ensure
+          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:bunnyclient][:collect_backtraces]
           AppOpticsAPM::API.log_exit(:'rabbitmq-client', kvs)
         end
       end

--- a/lib/appoptics_apm/inst/bunny-client.rb
+++ b/lib/appoptics_apm/inst/bunny-client.rb
@@ -5,7 +5,7 @@ module AppOpticsAPM
   module Inst
     module BunnyExchange
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :delete, ::Bunny::Exchange)
+        AppOpticsAPM::Util.method_alias(klass, :delete, ::Bunny::Exchange)
       end
 
       def delete_with_appoptics(opts = {})
@@ -42,9 +42,9 @@ module AppOpticsAPM
 
     module BunnyChannel
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :basic_publish,     ::Bunny::Channel)
-        ::AppOpticsAPM::Util.method_alias(klass, :queue,             ::Bunny::Channel)
-        ::AppOpticsAPM::Util.method_alias(klass, :wait_for_confirms, ::Bunny::Channel)
+        AppOpticsAPM::Util.method_alias(klass, :basic_publish,     ::Bunny::Channel)
+        AppOpticsAPM::Util.method_alias(klass, :queue,             ::Bunny::Channel)
+        AppOpticsAPM::Util.method_alias(klass, :wait_for_confirms, ::Bunny::Channel)
       end
 
       def collect_channel_kvs
@@ -141,8 +141,8 @@ module AppOpticsAPM
   end
 end
 
-if AppOpticsAPM::Config[:bunnyclient][:enabled] && defined?(::Bunny)
-  ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting bunny client' if AppOpticsAPM::Config[:verbose]
-  ::AppOpticsAPM::Util.send_include(::Bunny::Exchange, ::AppOpticsAPM::Inst::BunnyExchange)
-  ::AppOpticsAPM::Util.send_include(::Bunny::Channel, ::AppOpticsAPM::Inst::BunnyChannel)
+if defined?(Bunny) && AppOpticsAPM::Config[:bunnyclient][:enabled]
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting bunny client' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM::Util.send_include(Bunny::Exchange, AppOpticsAPM::Inst::BunnyExchange)
+  AppOpticsAPM::Util.send_include(Bunny::Channel, AppOpticsAPM::Inst::BunnyChannel)
 end

--- a/lib/appoptics_apm/inst/bunny-consumer.rb
+++ b/lib/appoptics_apm/inst/bunny-consumer.rb
@@ -5,7 +5,7 @@ module AppOpticsAPM
   module Inst
     module BunnyConsumer
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :call, ::Bunny::Consumer)
+        AppOpticsAPM::Util.method_alias(klass, :call, ::Bunny::Consumer)
       end
 
       def collect_consumer_kvs(args)
@@ -83,7 +83,7 @@ module AppOpticsAPM
   end
 end
 
-if AppOpticsAPM::Config[:bunnyconsumer][:enabled] && defined?(::Bunny)
-  ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting bunny consumer' if AppOpticsAPM::Config[:verbose]
-  ::AppOpticsAPM::Util.send_include(::Bunny::Consumer, ::AppOpticsAPM::Inst::BunnyConsumer)
+if AppOpticsAPM::Config[:bunnyconsumer][:enabled] && defined?(Bunny)
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting bunny consumer' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM::Util.send_include(Bunny::Consumer, AppOpticsAPM::Inst::BunnyConsumer)
 end

--- a/lib/appoptics_apm/inst/bunny-consumer.rb
+++ b/lib/appoptics_apm/inst/bunny-consumer.rb
@@ -9,59 +9,57 @@ module AppOpticsAPM
       end
 
       def collect_consumer_kvs(args)
-        begin
-          kvs = {}
-          kvs[:Spec] = :job
-          kvs[:Flavor] = :rabbitmq
-          kvs[:RemoteHost]  = @channel.connection.host
-          kvs[:RemotePort]  = @channel.connection.port.to_i
-          kvs[:VirtualHost] = @channel.connection.vhost
+        kvs = {}
+        kvs[:Spec] = :job
+        kvs[:Flavor] = :rabbitmq
+        kvs[:RemoteHost]  = @channel.connection.host
+        kvs[:RemotePort]  = @channel.connection.port.to_i
+        kvs[:VirtualHost] = @channel.connection.vhost
 
-          mp = args[1]
-          kvs[:RoutingKey] = args[0].routing_key if args[0].routing_key
-          kvs[:MsgID]      = args[1].message_id  if mp.message_id
-          kvs[:AppID]      = args[1].app_id      if mp.app_id
-          kvs[:Priority]   = args[1].priority    if mp.priority
+        mp = args[1]
+        kvs[:RoutingKey] = args[0].routing_key if args[0].routing_key
+        kvs[:MsgID]      = args[1].message_id  if mp.message_id
+        kvs[:AppID]      = args[1].app_id      if mp.app_id
+        kvs[:Priority]   = args[1].priority    if mp.priority
 
-          if @queue.respond_to?(:name)
-            kvs[:Queue] = @queue.name
-          else
-            kvs[:Queue] = @queue
-          end
-
-          # Report configurable Controller/Action KVs
-          # See AppOpticsAPM::Config[:bunnyconsumer] in lib/appoptics_apm/config.rb
-          # Used for dashboard trace filtering
-          controller_key = AppOpticsAPM::Config[:bunnyconsumer][:controller]
-          if mp.respond_to?(controller_key)
-            value = mp.method(controller_key).call
-            kvs[:Controller] = value if value
-          end
-
-          action_key = AppOpticsAPM::Config[:bunnyconsumer][:action]
-          if mp.respond_to?(action_key)
-            value = mp.method(action_key).call
-            kvs[:Action] = value if value
-          end
-
-          if kvs[:Queue]
-            kvs[:URL] = "/bunny/#{kvs[:Queue]}"
-          else
-            kvs[:URL] = "/bunny/consumer"
-          end
-
-          if AppOpticsAPM::Config[:bunnyconsumer][:log_args] && @arguments
-            kvs[:Args] = @arguments.to_s
-          end
-
-          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:bunnyconsumer][:collect_backtraces]
-
-          kvs
-        rescue => e
-          AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
-        ensure
-          return kvs
+        if @queue.respond_to?(:name)
+          kvs[:Queue] = @queue.name
+        else
+          kvs[:Queue] = @queue
         end
+
+        # Report configurable Controller/Action KVs
+        # See AppOpticsAPM::Config[:bunnyconsumer] in lib/appoptics_apm/config.rb
+        # Used for dashboard trace filtering
+        controller_key = AppOpticsAPM::Config[:bunnyconsumer][:controller]
+        if mp.respond_to?(controller_key)
+          value = mp.method(controller_key).call
+          kvs[:Controller] = value if value
+        end
+
+        action_key = AppOpticsAPM::Config[:bunnyconsumer][:action]
+        if mp.respond_to?(action_key)
+          value = mp.method(action_key).call
+          kvs[:Action] = value if value
+        end
+
+        if kvs[:Queue]
+          kvs[:URL] = "/bunny/#{kvs[:Queue]}"
+        else
+          kvs[:URL] = "/bunny/consumer"
+        end
+
+        if AppOpticsAPM::Config[:bunnyconsumer][:log_args] && @arguments
+          kvs[:Args] = @arguments.to_s
+        end
+
+        kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:bunnyconsumer][:collect_backtraces]
+
+        kvs
+      rescue => e
+        AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
+      ensure
+        return kvs
       end
 
       def call_with_appoptics(*args)

--- a/lib/appoptics_apm/inst/curb.rb
+++ b/lib/appoptics_apm/inst/curb.rb
@@ -106,10 +106,10 @@ module AppOpticsAPM
       include AppOpticsAPM::Inst::CurlUtility
 
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :http, ::Curl::Easy)
-        ::AppOpticsAPM::Util.method_alias(klass, :perform, ::Curl::Easy)
-        ::AppOpticsAPM::Util.method_alias(klass, :http_put, ::Curl::Easy)
-        ::AppOpticsAPM::Util.method_alias(klass, :http_post, ::Curl::Easy)
+        AppOpticsAPM::Util.method_alias(klass, :http, ::Curl::Easy)
+        AppOpticsAPM::Util.method_alias(klass, :perform, ::Curl::Easy)
+        AppOpticsAPM::Util.method_alias(klass, :http_put, ::Curl::Easy)
+        AppOpticsAPM::Util.method_alias(klass, :http_post, ::Curl::Easy)
       end
 
       ##
@@ -212,7 +212,7 @@ module AppOpticsAPM
       include AppOpticsAPM::Inst::CurlUtility
 
       def self.extended(klass)
-        ::AppOpticsAPM::Util.class_method_alias(klass, :http, ::Curl::Multi)
+        AppOpticsAPM::Util.class_method_alias(klass, :http, ::Curl::Multi)
       end
 
       ##
@@ -275,7 +275,7 @@ module AppOpticsAPM
       include AppOpticsAPM::Inst::CurlUtility
 
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :perform, ::Curl::Multi)
+        AppOpticsAPM::Util.method_alias(klass, :perform, ::Curl::Multi)
       end
 
       ##
@@ -323,8 +323,8 @@ module AppOpticsAPM
 end
 
 if AppOpticsAPM::Config[:curb][:enabled] && defined?(::Curl)
-  ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting curb' if AppOpticsAPM::Config[:verbose]
-  ::AppOpticsAPM::Util.send_include(::Curl::Easy, ::AppOpticsAPM::Inst::CurlEasy)
-  ::AppOpticsAPM::Util.send_extend(::Curl::Multi, ::AppOpticsAPM::Inst::CurlMultiCM)
-  ::AppOpticsAPM::Util.send_include(::Curl::Multi, ::AppOpticsAPM::Inst::CurlMultiIM)
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting curb' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM::Util.send_include(::Curl::Easy, AppOpticsAPM::Inst::CurlEasy)
+  AppOpticsAPM::Util.send_extend(::Curl::Multi, AppOpticsAPM::Inst::CurlMultiCM)
+  AppOpticsAPM::Util.send_include(::Curl::Multi, AppOpticsAPM::Inst::CurlMultiIM)
 end

--- a/lib/appoptics_apm/inst/curb.rb
+++ b/lib/appoptics_apm/inst/curb.rb
@@ -33,7 +33,6 @@ module AppOpticsAPM
 
         # Avoid cross host tracing for blacklisted domains
         kvs[:blacklisted] = AppOpticsAPM::API.blacklisted?(URI(url).hostname)
-        kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:curb][:collect_backtraces]
 
         kvs
       rescue => e
@@ -94,6 +93,7 @@ module AppOpticsAPM
           AppOpticsAPM::API.log_exception(:curb, e)
           raise e
         ensure
+          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:curb][:collect_backtraces]
           AppOpticsAPM::API.log_exit(:curb, kvs)
         end
       end

--- a/lib/appoptics_apm/inst/dalli.rb
+++ b/lib/appoptics_apm/inst/dalli.rb
@@ -42,7 +42,6 @@ module AppOpticsAPM
             report_kvs[:KVHit] = memcache_hit?(result) if op == :get && key.class == String
             report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:dalli][:collect_backtraces]
 
-            AppOpticsAPM::API.log(:memcache, :info, report_kvs) unless report_kvs.empty?
             result
           end
         else
@@ -65,12 +64,12 @@ module AppOpticsAPM
           AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
         end
 
-        AppOpticsAPM::API.trace(:memcache, { :KVOp => :get_multi }, :get_multi) do
+        info_kvs[:KVOp] = :get_multi
+        info_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:dalli][:collect_backtraces]
+        AppOpticsAPM::API.trace(:memcache, info_kvs, :get_multi) do
           values = get_multi_without_appoptics(*keys)
 
           info_kvs[:KVHitCount] = values.length
-          info_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:dalli][:collect_backtraces]
-          AppOpticsAPM::API.log(:memcache, :info, info_kvs)
 
           values
         end

--- a/lib/appoptics_apm/inst/delayed_job.rb
+++ b/lib/appoptics_apm/inst/delayed_job.rb
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
-if defined?(::Delayed)
+if defined?(Delayed)
   module AppOpticsAPM
     module Inst
       module DelayedJob
@@ -13,12 +13,12 @@ if defined?(::Delayed)
         #
         module ForkHandler
           def self.extended(klass)
-            ::AppOpticsAPM::Util.class_method_alias(klass, :after_fork, ::Delayed::Worker)
+            AppOpticsAPM::Util.class_method_alias(klass, :after_fork, ::Delayed::Worker)
           end
 
           def after_fork_with_appoptics
-            ::AppOpticsAPM.logger.info '[appoptics_apm/delayed_job] Detected fork.  Restarting AppOpticsAPM reporter.' if AppOpticsAPM::Config[:verbose]
-            ::AppOpticsAPM::Reporter.restart unless ENV.key?('APPOPTICS_GEM_TEST')
+            AppOpticsAPM.logger.info '[appoptics_apm/delayed_job] Detected fork.  Restarting AppOpticsAPM reporter.' if AppOpticsAPM::Config[:verbose]
+            AppOpticsAPM::Reporter.restart unless ENV.key?('APPOPTICS_GEM_TEST')
 
             after_fork_without_appoptics
           end
@@ -86,7 +86,7 @@ if defined?(::Delayed)
     end
   end
 
-  ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting delayed_job' if AppOpticsAPM::Config[:verbose]
-  ::AppOpticsAPM::Util.send_extend(::Delayed::Worker, ::AppOpticsAPM::Inst::DelayedJob::ForkHandler)
-  ::Delayed::Worker.plugins << ::AppOpticsAPM::Inst::DelayedJob::Plugin
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting delayed_job' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM::Util.send_extend(::Delayed::Worker, AppOpticsAPM::Inst::DelayedJob::ForkHandler)
+  Delayed::Worker.plugins << AppOpticsAPM::Inst::DelayedJob::Plugin
 end

--- a/lib/appoptics_apm/inst/em-http-request.rb
+++ b/lib/appoptics_apm/inst/em-http-request.rb
@@ -18,15 +18,12 @@ module AppOpticsAPM
               report_kvs[:RemoteURL] = @uri
               report_kvs[:HTTPMethod] = args[0]
               report_kvs[:Blacklisted] = true if blacklisted
-
-              if AppOpticsAPM::Config[:em_http_request][:collect_backtraces]
-                report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace
-              end
+              report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:em_http_request][:collect_backtraces]
             rescue => e
               AppOpticsAPM.logger.debug "[appoptics_apm/debug] em-http-request KV error: #{e.inspect}"
             end
 
-            ::AppOpticsAPM::API.log_entry('em-http-request', report_kvs)
+            context = AppOpticsAPM::API.log_entry('em-http-request', report_kvs)
           end
           client = setup_request_without_appoptics(*args, &block)
           client.req.headers['X-Trace'] = context unless blacklisted

--- a/lib/appoptics_apm/inst/em-http-request.rb
+++ b/lib/appoptics_apm/inst/em-http-request.rb
@@ -67,17 +67,17 @@ module AppOpticsAPM
 
           end
         ensure
-          ::AppOpticsAPM::API.log_exit(:'em-http-request', report_kvs)
+          AppOpticsAPM::API.log_exit(:'em-http-request', report_kvs)
         end
       end
     end
   end
 end
 
-if defined?(::EventMachine::HttpConnection) && defined?(::EventMachine::HttpClient) && AppOpticsAPM::Config[:em_http_request][:enabled]
+if defined?(EventMachine::HttpConnection) && defined?(EventMachine::HttpClient) && AppOpticsAPM::Config[:em_http_request][:enabled]
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting em-http-request' if AppOpticsAPM::Config[:verbose]
 
-  class ::EventMachine::HttpConnection
+  class EventMachine::HttpConnection
     include AppOpticsAPM::Inst::EventMachine::HttpConnection
 
     if method_defined?(:setup_request)
@@ -88,7 +88,7 @@ if defined?(::EventMachine::HttpConnection) && defined?(::EventMachine::HttpClie
     end
   end
 
-  class ::EventMachine::HttpClient
+  class EventMachine::HttpClient
     include AppOpticsAPM::Inst::EventMachine::HttpClient
 
     if method_defined?(:parse_response_header)

--- a/lib/appoptics_apm/inst/excon.rb
+++ b/lib/appoptics_apm/inst/excon.rb
@@ -40,7 +40,6 @@ module AppOpticsAPM
         else
           kvs[:HTTPMethod] = ::AppOpticsAPM::Util.upcase(params[:method])
         end
-        kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:excon][:collect_backtraces]
         kvs
       rescue => e
         AppOpticsAPM.logger.debug "[appoptics_apm/debug] Error capturing excon KVs: #{e.message}"
@@ -55,6 +54,7 @@ module AppOpticsAPM
         responses = nil
         kvs = appoptics_collect(pipeline_params)
         AppOpticsAPM::API.trace(:excon, kvs) do
+          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:excon][:collect_backtraces]
           responses = requests_without_appoptics(pipeline_params)
           kvs[:HTTPStatuses] = responses.map { |r| r.status }.join(',')
         end
@@ -111,6 +111,7 @@ module AppOpticsAPM
           AppOpticsAPM::API.log_exception(:excon, e)
           raise e
         ensure
+          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:excon][:collect_backtraces]
           AppOpticsAPM::API.log_exit(:excon, kvs) unless params[:pipeline]
         end
       end

--- a/lib/appoptics_apm/inst/excon.rb
+++ b/lib/appoptics_apm/inst/excon.rb
@@ -5,8 +5,8 @@ module AppOpticsAPM
   module Inst
     module ExconConnection
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :request, ::Excon::Connection)
-        ::AppOpticsAPM::Util.method_alias(klass, :requests, ::Excon::Connection)
+        AppOpticsAPM::Util.method_alias(klass, :request, ::Excon::Connection)
+        AppOpticsAPM::Util.method_alias(klass, :requests, ::Excon::Connection)
       end
 
       private
@@ -33,17 +33,17 @@ module AppOpticsAPM
         if params.is_a?(Array)
           methods = []
           params.each do |p|
-            methods << ::AppOpticsAPM::Util.upcase(p[:method])
+            methods << AppOpticsAPM::Util.upcase(p[:method])
           end
           kvs[:HTTPMethods] = methods.join(',')[0..1024]
           kvs[:Pipeline] = true
         else
-          kvs[:HTTPMethod] = ::AppOpticsAPM::Util.upcase(params[:method])
+          kvs[:HTTPMethod] = AppOpticsAPM::Util.upcase(params[:method])
         end
         kvs
       rescue => e
         AppOpticsAPM.logger.debug "[appoptics_apm/debug] Error capturing excon KVs: #{e.message}"
-        AppOpticsAPM.logger.debug e.backtrace.join('\n') if ::AppOpticsAPM::Config[:verbose]
+        AppOpticsAPM.logger.debug e.backtrace.join('\n') if AppOpticsAPM::Config[:verbose]
       ensure
         return kvs
       end
@@ -119,7 +119,7 @@ module AppOpticsAPM
   end
 end
 
-if AppOpticsAPM::Config[:excon][:enabled] && defined?(::Excon)
-  ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting excon' if AppOpticsAPM::Config[:verbose]
-  ::AppOpticsAPM::Util.send_include(::Excon::Connection, ::AppOpticsAPM::Inst::ExconConnection)
+if AppOpticsAPM::Config[:excon][:enabled] && defined?(Excon)
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting excon' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM::Util.send_include(Excon::Connection, AppOpticsAPM::Inst::ExconConnection)
 end

--- a/lib/appoptics_apm/inst/faraday.rb
+++ b/lib/appoptics_apm/inst/faraday.rb
@@ -5,7 +5,7 @@ module AppOpticsAPM
   module Inst
     module FaradayConnection
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :run_request, ::Faraday::Connection)
+        AppOpticsAPM::Util.method_alias(klass, :run_request, ::Faraday::Connection)
       end
 
       def run_request_with_appoptics(method, url, body, headers, &block)
@@ -86,11 +86,9 @@ module AppOpticsAPM
   end
 end
 
-if AppOpticsAPM::Config[:faraday][:enabled]
-  if defined?(::Faraday)
-    AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting faraday' if AppOpticsAPM::Config[:verbose]
-    ::AppOpticsAPM::Util.send_include(::Faraday::Connection, ::AppOpticsAPM::Inst::FaradayConnection)
-    APPOPTICS_INSTR_ADAPTERS = ["Faraday::Adapter::NetHttp", "Faraday::Adapter::Excon", "Faraday::Adapter::Typhoeus"]
-    APPOPTICS_INSTR_ADAPTERS << "Faraday::Adapter::HTTPClient" if defined?Faraday::Adapter::HTTPClient
-  end
+if defined?(Faraday) && AppOpticsAPM::Config[:faraday][:enabled]
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting faraday' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM::Util.send_include(Faraday::Connection, AppOpticsAPM::Inst::FaradayConnection)
+  APPOPTICS_INSTR_ADAPTERS = ["Faraday::Adapter::NetHttp", "Faraday::Adapter::Excon", "Faraday::Adapter::Typhoeus"]
+  APPOPTICS_INSTR_ADAPTERS << "Faraday::Adapter::HTTPClient" if defined?Faraday::Adapter::HTTPClient
 end

--- a/lib/appoptics_apm/inst/grpc_client.rb
+++ b/lib/appoptics_apm/inst/grpc_client.rb
@@ -23,7 +23,6 @@ module AppOpticsAPM
                  'GRPCMethodType' => method_type,
                  'IsService' => 'True'
         }
-        tags['Backtrace'] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:grpc_client][:collect_backtraces]
         tags
       end
 
@@ -127,7 +126,7 @@ module AppOpticsAPM
       def exit_tags(tags)
         # we need to translate the status.code, it is not the status.details we want, they are not matching 1:1
         tags['GRPCStatus'] ||= @call.status ? StatusCodes[@call.status.code].to_s : 'UNKNOWN'
-        tags.delete('Backtrace')
+        tags['Backtrace'] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:grpc_client][:collect_backtraces]
         tags
       end
     end

--- a/lib/appoptics_apm/inst/grpc_client.rb
+++ b/lib/appoptics_apm/inst/grpc_client.rb
@@ -11,10 +11,10 @@ module AppOpticsAPM
       end
 
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :request_response, ::GRPC::ActiveCall)
-        ::AppOpticsAPM::Util.method_alias(klass, :client_streamer, ::GRPC::ActiveCall)
-        ::AppOpticsAPM::Util.method_alias(klass, :server_streamer, ::GRPC::ActiveCall)
-        ::AppOpticsAPM::Util.method_alias(klass, :bidi_streamer, ::GRPC::ActiveCall)
+        AppOpticsAPM::Util.method_alias(klass, :request_response, ::GRPC::ActiveCall)
+        AppOpticsAPM::Util.method_alias(klass, :client_streamer, ::GRPC::ActiveCall)
+        AppOpticsAPM::Util.method_alias(klass, :server_streamer, ::GRPC::ActiveCall)
+        AppOpticsAPM::Util.method_alias(klass, :bidi_streamer, ::GRPC::ActiveCall)
       end
 
       def grpc_tags(method_type, method)
@@ -134,11 +134,11 @@ module AppOpticsAPM
   end
 end
 
-if defined?(::GRPC) && AppOpticsAPM::Config[:grpc_client][:enabled]
+if defined?(GRPC) && AppOpticsAPM::Config[:grpc_client][:enabled]
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting GRPC' if AppOpticsAPM::Config[:verbose]
 
   # Client side is instrumented in ActiveCall and ClientStub
-  ::AppOpticsAPM::Util.send_include(::GRPC::ActiveCall, ::AppOpticsAPM::GRPC::ActiveCall)
+  AppOpticsAPM::Util.send_include(GRPC::ActiveCall, AppOpticsAPM::GRPC::ActiveCall)
 
   GRPC_ClientStub_ops = [:request_response, :client_streamer, :server_streamer, :bidi_streamer]
   module GRPC
@@ -154,7 +154,7 @@ if defined?(::GRPC) && AppOpticsAPM::Config[:grpc_client][:enabled]
                       credentials: credentials, metadata: metadata, &blk)
         end
 
-        ::AppOpticsAPM::Util.method_alias(::GRPC::ClientStub, m)
+        AppOpticsAPM::Util.method_alias(GRPC::ClientStub, m)
       end
 
     end

--- a/lib/appoptics_apm/inst/httpclient.rb
+++ b/lib/appoptics_apm/inst/httpclient.rb
@@ -5,9 +5,9 @@ module AppOpticsAPM
   module Inst
     module HTTPClient
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :do_request, ::HTTPClient)
-        ::AppOpticsAPM::Util.method_alias(klass, :do_request_async, ::HTTPClient)
-        ::AppOpticsAPM::Util.method_alias(klass, :do_get_stream, ::HTTPClient)
+        AppOpticsAPM::Util.method_alias(klass, :do_request, ::HTTPClient)
+        AppOpticsAPM::Util.method_alias(klass, :do_request_async, ::HTTPClient)
+        AppOpticsAPM::Util.method_alias(klass, :do_get_stream, ::HTTPClient)
       end
 
       def appoptics_collect(method, uri, query = nil)
@@ -28,11 +28,11 @@ module AppOpticsAPM
           kvs[:RemoteURL] = uri.to_s.split('?').first
         end
 
-        kvs[:HTTPMethod] = ::AppOpticsAPM::Util.upcase(method)
+        kvs[:HTTPMethod] = AppOpticsAPM::Util.upcase(method)
         kvs
       rescue => e
         AppOpticsAPM.logger.debug "[appoptics_apm/debug] Error capturing httpclient KVs: #{e.message}"
-        AppOpticsAPM.logger.debug e.backtrace.join('\n') if ::AppOpticsAPM::Config[:verbose]
+        AppOpticsAPM.logger.debug e.backtrace.join('\n') if AppOpticsAPM::Config[:verbose]
       ensure
         return kvs
       end
@@ -169,7 +169,7 @@ module AppOpticsAPM
   end
 end
 
-if AppOpticsAPM::Config[:httpclient][:enabled] && defined?(::HTTPClient)
-  ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting httpclient' if AppOpticsAPM::Config[:verbose]
-  ::AppOpticsAPM::Util.send_include(::HTTPClient, ::AppOpticsAPM::Inst::HTTPClient)
+if AppOpticsAPM::Config[:httpclient][:enabled] && defined?(HTTPClient)
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting httpclient' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM::Util.send_include(HTTPClient, AppOpticsAPM::Inst::HTTPClient)
 end

--- a/lib/appoptics_apm/inst/httpclient.rb
+++ b/lib/appoptics_apm/inst/httpclient.rb
@@ -29,7 +29,6 @@ module AppOpticsAPM
         end
 
         kvs[:HTTPMethod] = ::AppOpticsAPM::Util.upcase(method)
-        kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:httpclient][:collect_backtraces]
         kvs
       rescue => e
         AppOpticsAPM.logger.debug "[appoptics_apm/debug] Error capturing httpclient KVs: #{e.message}"
@@ -80,6 +79,7 @@ module AppOpticsAPM
           AppOpticsAPM::API.log_exception(:httpclient, e)
           raise e
         ensure
+          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:httpclient][:collect_backtraces]
           AppOpticsAPM::API.log_exit(:httpclient, kvs)
         end
       end
@@ -144,6 +144,7 @@ module AppOpticsAPM
           raise e
         ensure
           # AppOpticsAPM::API.log_exit('httpclient', kvs.merge('Async' => 1))
+          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:httpclient][:collect_backtraces]
           AppOpticsAPM::API.log_exit(:httpclient, kvs)
         end
       end

--- a/lib/appoptics_apm/inst/memcached.rb
+++ b/lib/appoptics_apm/inst/memcached.rb
@@ -73,13 +73,13 @@ module AppOpticsAPM
   end # module Inst
 end # module AppOpticsAPM
 
-if defined?(::Memcached) && AppOpticsAPM::Config[:memcached][:enabled]
-  ::Memcached.class_eval do
+if defined?(Memcached) && AppOpticsAPM::Config[:memcached][:enabled]
+  Memcached.class_eval do
     include AppOpticsAPM::Inst::Memcached
   end
 
-  if defined?(::Memcached::Rails)
-    ::Memcached::Rails.class_eval do
+  if defined?(Memcached::Rails)
+    Memcached::Rails.class_eval do
       include AppOpticsAPM::Inst::MemcachedRails
     end
   end

--- a/lib/appoptics_apm/inst/memcached.rb
+++ b/lib/appoptics_apm/inst/memcached.rb
@@ -23,11 +23,9 @@ module AppOpticsAPM
               AppOpticsAPM::API.trace(:memcache, opts) do
                 result = send("#{m}_without_appoptics", *args)
 
-                info_kvs = {}
-                info_kvs[:KVHit] = memcache_hit?(result) if m == :get && args.length && args[0].class == String
-                info_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:memcached][:collect_backtraces]
+                opts[:KVHit] = memcache_hit?(result) if m == :get && args.length && args[0].class == String
+                opts[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:memcached][:collect_backtraces]
 
-                AppOpticsAPM::API.log(:memcache, :info, info_kvs) unless info_kvs.empty?
                 result
               end
             end
@@ -58,15 +56,13 @@ module AppOpticsAPM
           layer_kvs[:KVOp] = :get_multi
 
           AppOpticsAPM::API.trace(:memcache, layer_kvs || {}, :get_multi) do
-            info_kvs = {}
-            info_kvs[:KVKeyCount] = keys.flatten.length
+            layer_kvs[:KVKeyCount] = keys.flatten.length
 
             values = get_multi_without_appoptics(keys, raw)
 
-            info_kvs[:KVHitCount] = values.length
-            info_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:memcached][:collect_backtraces]
+            layer_kvs[:KVHitCount] = values.length
+            layer_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:memcached][:collect_backtraces]
 
-            AppOpticsAPM::API.log(:memcache, :info, info_kvs)
             values
           end
         else

--- a/lib/appoptics_apm/inst/mongo.rb
+++ b/lib/appoptics_apm/inst/mongo.rb
@@ -22,6 +22,7 @@ module AppOpticsAPM
   end
 end
 
+# TODO find out if we still need to support mongo < '2.0.0', we don't run tests for it. 1.12.5 was released Dec 2015
 if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && AppOpticsAPM::Config[:mongo][:enabled]
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting mongo' if AppOpticsAPM::Config[:verbose]
 
@@ -55,13 +56,13 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Ap
               report_kvs[:New_Collection_Name] = args[0] if m == :create_collection
               report_kvs[:Collection] = args[0]          if m == :drop_collection
 
-              report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:mongo][:collect_backtraces]
             rescue => e
               AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
             end
 
             AppOpticsAPM::API.trace(:mongo, report_kvs) do
               send("#{m}_without_appoptics", *args)
+              report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:mongo][:collect_backtraces]
             end
           end
 
@@ -104,6 +105,7 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Ap
 
             AppOpticsAPM::API.trace(:mongo, report_kvs) do
               send("#{m}_without_appoptics", *args)
+              report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:mongo][:collect_backtraces]
             end
           end
 
@@ -127,8 +129,6 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Ap
           kvs[:RemoteHost] = @db.connection.host
           kvs[:RemotePort] = @db.connection.port
           kvs[:Collection] = @name
-
-          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:mongo][:collect_backtraces]
 
           kvs[:QueryOp] = m
           kvs[:Query] = args[0].to_json if args && !args.empty? && args[0].class == Hash
@@ -168,6 +168,7 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Ap
             end
 
             AppOpticsAPM::API.trace(:mongo, report_kvs) do
+              report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:mongo][:collect_backtraces]
               send("#{m}_without_appoptics", *args)
             end
           end
@@ -207,6 +208,7 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Ap
             end
 
             AppOpticsAPM::API.trace(:mongo, report_kvs) do
+              report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:mongo][:collect_backtraces]
               send("#{m}_without_appoptics", *args, &blk)
             end
           end
@@ -229,6 +231,7 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Ap
             end
 
             AppOpticsAPM::API.trace(:mongo, report_kvs) do
+              report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:mongo][:collect_backtraces]
               send("#{m}_without_appoptics", *args)
             end
           end

--- a/lib/appoptics_apm/inst/mongo.rb
+++ b/lib/appoptics_apm/inst/mongo.rb
@@ -23,11 +23,11 @@ module AppOpticsAPM
 end
 
 # TODO find out if we still need to support mongo < '2.0.0', we don't run tests for it. 1.12.5 was released Dec 2015
-if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && AppOpticsAPM::Config[:mongo][:enabled]
+if defined?(Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && AppOpticsAPM::Config[:mongo][:enabled]
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting mongo' if AppOpticsAPM::Config[:verbose]
 
-  if defined?(::Mongo::DB)
-    module ::Mongo
+  if defined?(Mongo::DB)
+    module Mongo
       class DB
         include AppOpticsAPM::Inst::Mongo
 
@@ -73,8 +73,8 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Ap
     end
   end
 
-  if defined?(::Mongo::Cursor)
-    module ::Mongo
+  if defined?(Mongo::Cursor)
+    module Mongo
       class Cursor
         include AppOpticsAPM::Inst::Mongo
 
@@ -116,8 +116,8 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Ap
     end
   end
 
-  if defined?(::Mongo::Collection)
-    module ::Mongo
+  if defined?(Mongo::Collection)
+    module Mongo
       class Collection
         include AppOpticsAPM::Inst::Mongo
 

--- a/lib/appoptics_apm/inst/mongo2.rb
+++ b/lib/appoptics_apm/inst/mongo2.rb
@@ -4,8 +4,8 @@
 require 'json'
 
 if AppOpticsAPM::Config[:mongo][:enabled]
-  if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s >= '2.0.0')
-    ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting mongo' if AppOpticsAPM::Config[:verbose]
+  if defined?(Mongo) && (Gem.loaded_specs['mongo'].version.to_s >= '2.0.0')
+    AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting mongo' if AppOpticsAPM::Config[:verbose]
 
     # Collection Related Operations
     COLL_OTHER_OPS = [:create, :drop, :insert_one, :insert_many, :bulk_write, :map_reduce].freeze
@@ -81,7 +81,7 @@ if AppOpticsAPM::Config[:mongo][:enabled]
               AppOpticsAPM::API.log_exit(:mongo) unless mongo_skipped
             end
           end
-          ::AppOpticsAPM::Util.method_alias(Mongo::Collection, m)
+          AppOpticsAPM::Util.method_alias(Mongo::Collection, m)
         end
       end
     end
@@ -158,7 +158,7 @@ if AppOpticsAPM::Config[:mongo][:enabled]
                 AppOpticsAPM::API.log_exit(:mongo) unless mongo_skipped
               end
             end
-            ::AppOpticsAPM::Util.method_alias(Mongo::Collection::View, m)
+            AppOpticsAPM::Util.method_alias(Mongo::Collection::View, m)
           end
         end
       end
@@ -216,7 +216,7 @@ if AppOpticsAPM::Config[:mongo][:enabled]
                 AppOpticsAPM::API.log_exit(:mongo) unless mongo_skipped
               end
             end
-            ::AppOpticsAPM::Util.method_alias(Mongo::Index::View, m)
+            AppOpticsAPM::Util.method_alias(Mongo::Index::View, m)
           end
         end
       end

--- a/lib/appoptics_apm/inst/moped.rb
+++ b/lib/appoptics_apm/inst/moped.rb
@@ -47,7 +47,7 @@ module AppOpticsAPM
 
       def self.included(klass)
         AppOpticsAPM::Inst::Moped::DB_OPS.each do |m|
-          ::AppOpticsAPM::Util.method_alias(klass, m)
+          AppOpticsAPM::Util.method_alias(klass, m)
         end
       end
 
@@ -102,7 +102,7 @@ module AppOpticsAPM
 
       def self.included(klass)
         AppOpticsAPM::Inst::Moped::INDEX_OPS.each do |m|
-          ::AppOpticsAPM::Util.method_alias(klass, m)
+          AppOpticsAPM::Util.method_alias(klass, m)
         end
       end
 
@@ -170,7 +170,7 @@ module AppOpticsAPM
 
       def self.included(klass)
         AppOpticsAPM::Inst::Moped::QUERY_OPS.each do |m|
-          ::AppOpticsAPM::Util.method_alias(klass, m)
+          AppOpticsAPM::Util.method_alias(klass, m)
         end
       end
 
@@ -375,7 +375,7 @@ module AppOpticsAPM
 
       def self.included(klass)
         AppOpticsAPM::Inst::Moped::COLLECTION_OPS.each do |m|
-          ::AppOpticsAPM::Util.method_alias(klass, m)
+          AppOpticsAPM::Util.method_alias(klass, m)
         end
       end
 
@@ -457,10 +457,10 @@ module AppOpticsAPM
   end
 end
 
-if defined?(::Moped) && AppOpticsAPM::Config[:moped][:enabled]
-  ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting moped' if AppOpticsAPM::Config[:verbose]
-  ::AppOpticsAPM::Util.send_include(::Moped::Database,   ::AppOpticsAPM::Inst::MopedDatabase)
-  ::AppOpticsAPM::Util.send_include(::Moped::Collection, ::AppOpticsAPM::Inst::MopedCollection)
-  ::AppOpticsAPM::Util.send_include(::Moped::Query,      ::AppOpticsAPM::Inst::MopedQuery)
-  ::AppOpticsAPM::Util.send_include(::Moped::Indexes,    ::AppOpticsAPM::Inst::MopedIndexes)
+if defined?(Moped) && AppOpticsAPM::Config[:moped][:enabled]
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting moped' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM::Util.send_include(Moped::Database,   AppOpticsAPM::Inst::MopedDatabase)
+  AppOpticsAPM::Util.send_include(Moped::Collection, AppOpticsAPM::Inst::MopedCollection)
+  AppOpticsAPM::Util.send_include(Moped::Query,      AppOpticsAPM::Inst::MopedQuery)
+  AppOpticsAPM::Util.send_include(Moped::Indexes,    AppOpticsAPM::Inst::MopedIndexes)
 end

--- a/lib/appoptics_apm/inst/rack.rb
+++ b/lib/appoptics_apm/inst/rack.rb
@@ -73,7 +73,7 @@ if AppOpticsAPM.loaded
           report_kvs[:'Forwarded-Proto']   = env['HTTP_X_FORWARDED_PROTO']  if env.key?('HTTP_X_FORWARDED_PROTO')
           report_kvs[:'Forwarded-Port']    = env['HTTP_X_FORWARDED_PORT']   if env.key?('HTTP_X_FORWARDED_PORT')
 
-          report_kvs[:'Ruby.AppOptics.Version'] = ::AppOpticsAPM::Version::STRING
+          report_kvs[:'Ruby.AppOptics.Version'] = AppOpticsAPM::Version::STRING
           report_kvs[:ProcessID]         = Process.pid
           report_kvs[:ThreadID]          = Thread.current.to_s[/0x\w*/]
         rescue StandardError => e
@@ -127,7 +127,7 @@ if AppOpticsAPM.loaded
         # AppOpticsAPM.has_xtrace_header = xtrace
         # AppOpticsAPM.is_continued_trace = AppOpticsAPM.has_incoming_context || AppOpticsAPM.has_xtrace_header
 
-        AppOpticsAPM::API.log_start(:rack, xtrace, report_kvs) unless ::AppOpticsAPM::Util.static_asset?(env['PATH_INFO'])
+        AppOpticsAPM::API.log_start(:rack, xtrace, report_kvs) unless AppOpticsAPM::Util.static_asset?(env['PATH_INFO'])
 
         status, headers, response = @app.call(env)
         confirmed_transaction_name = send_metrics(env, req, req_url, start, status)
@@ -153,7 +153,7 @@ if AppOpticsAPM.loaded
 
 
       def send_metrics(env, req, req_url, start, status)
-        return if ::AppOpticsAPM::Util.static_asset?(env['PATH_INFO'])
+        return if AppOpticsAPM::Util.static_asset?(env['PATH_INFO'])
 
         status = status.to_i
         error = status.between?(500,599) ? 1 : 0

--- a/lib/appoptics_apm/inst/redis.rb
+++ b/lib/appoptics_apm/inst/redis.rb
@@ -59,8 +59,8 @@ module AppOpticsAPM
         def self.included(klass)
           # We wrap two of the Redis methods to instrument
           # operations
-          ::AppOpticsAPM::Util.method_alias(klass, :call, ::Redis::Client)
-          ::AppOpticsAPM::Util.method_alias(klass, :call_pipeline, ::Redis::Client)
+          AppOpticsAPM::Util.method_alias(klass, :call, ::Redis::Client)
+          AppOpticsAPM::Util.method_alias(klass, :call_pipeline, ::Redis::Client)
         end
 
         # Given any Redis operation command array, this method
@@ -218,17 +218,17 @@ module AppOpticsAPM
         #
         def call_with_appoptics(command, &block)
           if AppOpticsAPM.tracing?
-            ::AppOpticsAPM::API.log_entry(:redis, {})
+            AppOpticsAPM::API.log_entry(:redis, {})
 
             begin
               r = call_without_appoptics(command, &block)
               report_kvs = extract_trace_details(command, r)
               r
             rescue StandardError => e
-              ::AppOpticsAPM::API.log_exception(:redis, e)
+              AppOpticsAPM::API.log_exception(:redis, e)
               raise
             ensure
-              ::AppOpticsAPM::API.log_exit(:redis, report_kvs)
+              AppOpticsAPM::API.log_exit(:redis, report_kvs)
             end
 
           else
@@ -246,17 +246,17 @@ module AppOpticsAPM
             # back on exit (a limitation of the AppOpticsAPM::API.trace
             # block method)  This removes the need for an info
             # event to send additonal KVs
-            ::AppOpticsAPM::API.log_entry(:redis, {})
+            AppOpticsAPM::API.log_entry(:redis, {})
 
             report_kvs = extract_pipeline_details(pipeline)
 
             begin
               call_pipeline_without_appoptics(pipeline)
             rescue StandardError => e
-              ::AppOpticsAPM::API.log_exception(:redis, e)
+              AppOpticsAPM::API.log_exception(:redis, e)
               raise
             ensure
-              ::AppOpticsAPM::API.log_exit(:redis, report_kvs)
+              AppOpticsAPM::API.log_exit(:redis, report_kvs)
             end
           else
             call_pipeline_without_appoptics(pipeline)
@@ -268,8 +268,8 @@ module AppOpticsAPM
 end
 
 if AppOpticsAPM::Config[:redis][:enabled]
-  if defined?(::Redis) && Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('3.0.0')
+  if defined?(Redis) && Gem::Version.new(Redis::VERSION) >= Gem::Version.new('3.0.0')
     AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting redis' if AppOpticsAPM::Config[:verbose]
-    ::AppOpticsAPM::Util.send_include(::Redis::Client, ::AppOpticsAPM::Inst::Redis::Client)
+    AppOpticsAPM::Util.send_include(Redis::Client, AppOpticsAPM::Inst::Redis::Client)
   end
 end

--- a/lib/appoptics_apm/inst/resque.rb
+++ b/lib/appoptics_apm/inst/resque.rb
@@ -9,9 +9,9 @@ module AppOpticsAPM
     module ResqueClient
       def self.included(klass)
         klass.send :extend, ::Resque
-        ::AppOpticsAPM::Util.method_alias(klass, :enqueue, ::Resque)
-        ::AppOpticsAPM::Util.method_alias(klass, :enqueue_to, ::Resque)
-        ::AppOpticsAPM::Util.method_alias(klass, :dequeue, ::Resque)
+        AppOpticsAPM::Util.method_alias(klass, :enqueue, ::Resque)
+        AppOpticsAPM::Util.method_alias(klass, :enqueue_to, ::Resque)
+        AppOpticsAPM::Util.method_alias(klass, :dequeue, ::Resque)
       end
 
       def extract_trace_details(op, klass, args)
@@ -81,7 +81,7 @@ module AppOpticsAPM
 
     module ResqueWorker
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :perform, ::Resque::Worker)
+        AppOpticsAPM::Util.method_alias(klass, :perform, ::Resque::Worker)
       end
 
       def perform_with_appoptics(job)
@@ -125,7 +125,7 @@ module AppOpticsAPM
 
     module ResqueJob
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :fail, ::Resque::Job)
+        AppOpticsAPM::Util.method_alias(klass, :fail, ::Resque::Job)
       end
 
       def fail_with_appoptics(exception)
@@ -138,13 +138,13 @@ module AppOpticsAPM
   end
 end
 
-if defined?(::Resque)
+if defined?(Resque)
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting resque' if AppOpticsAPM::Config[:verbose]
 
-  ::AppOpticsAPM::Util.send_include(::Resque,         ::AppOpticsAPM::Inst::ResqueClient) if AppOpticsAPM::Config[:resqueclient][:enabled]
-  ::AppOpticsAPM::Util.send_include(::Resque::Worker, ::AppOpticsAPM::Inst::ResqueWorker) if AppOpticsAPM::Config[:resqueworker][:enabled]
+  AppOpticsAPM::Util.send_include(Resque,         AppOpticsAPM::Inst::ResqueClient) if AppOpticsAPM::Config[:resqueclient][:enabled]
+  AppOpticsAPM::Util.send_include(Resque::Worker, AppOpticsAPM::Inst::ResqueWorker) if AppOpticsAPM::Config[:resqueworker][:enabled]
   if AppOpticsAPM::Config[:resqueclient][:enabled] || AppOpticsAPM::Config[:resqueworker][:enabled]
-    ::AppOpticsAPM::Util.send_include(::Resque::Job,    ::AppOpticsAPM::Inst::ResqueJob)
+    AppOpticsAPM::Util.send_include(Resque::Job,    AppOpticsAPM::Inst::ResqueJob)
   end
 end
 

--- a/lib/appoptics_apm/inst/rest-client.rb
+++ b/lib/appoptics_apm/inst/rest-client.rb
@@ -5,7 +5,7 @@ module AppOpticsAPM
   module Inst
     module RestClientRequest
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :execute, ::RestClient::Request)
+        AppOpticsAPM::Util.method_alias(klass, :execute, ::RestClient::Request)
       end
 
       ##
@@ -42,9 +42,7 @@ module AppOpticsAPM
   end
 end
 
-if AppOpticsAPM::Config[:rest_client][:enabled]
-  if defined?(::RestClient)
-    AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting rest-client' if AppOpticsAPM::Config[:verbose]
-    ::AppOpticsAPM::Util.send_include(::RestClient::Request, ::AppOpticsAPM::Inst::RestClientRequest)
-  end
+if defined?(RestClient) && AppOpticsAPM::Config[:rest_client][:enabled]
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting rest-client' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM::Util.send_include(RestClient::Request, AppOpticsAPM::Inst::RestClientRequest)
 end

--- a/lib/appoptics_apm/inst/sequel.rb
+++ b/lib/appoptics_apm/inst/sequel.rb
@@ -86,10 +86,10 @@ module AppOpticsAPM
       include AppOpticsAPM::Inst::Sequel
 
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :run, ::Sequel::Database)
-        ::AppOpticsAPM::Util.method_alias(klass, :execute_ddl, ::Sequel::Database)
-        ::AppOpticsAPM::Util.method_alias(klass, :execute_dui, ::Sequel::Database)
-        ::AppOpticsAPM::Util.method_alias(klass, :execute_insert, ::Sequel::Database)
+        AppOpticsAPM::Util.method_alias(klass, :run, ::Sequel::Database)
+        AppOpticsAPM::Util.method_alias(klass, :execute_ddl, ::Sequel::Database)
+        AppOpticsAPM::Util.method_alias(klass, :execute_dui, ::Sequel::Database)
+        AppOpticsAPM::Util.method_alias(klass, :execute_insert, ::Sequel::Database)
       end
 
       def run_with_appoptics(sql, opts = ::Sequel::OPTS)
@@ -135,10 +135,10 @@ module AppOpticsAPM
       include AppOpticsAPM::Inst::Sequel
 
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :execute, ::Sequel::Dataset)
-        ::AppOpticsAPM::Util.method_alias(klass, :execute_ddl, ::Sequel::Dataset)
-        ::AppOpticsAPM::Util.method_alias(klass, :execute_dui, ::Sequel::Dataset)
-        ::AppOpticsAPM::Util.method_alias(klass, :execute_insert, ::Sequel::Dataset)
+        AppOpticsAPM::Util.method_alias(klass, :execute, ::Sequel::Dataset)
+        AppOpticsAPM::Util.method_alias(klass, :execute_ddl, ::Sequel::Dataset)
+        AppOpticsAPM::Util.method_alias(klass, :execute_dui, ::Sequel::Dataset)
+        AppOpticsAPM::Util.method_alias(klass, :execute_insert, ::Sequel::Dataset)
       end
 
       def execute_with_appoptics(sql, opts = ::Sequel::OPTS, &block)
@@ -172,7 +172,7 @@ if AppOpticsAPM::Config[:sequel][:enabled]
 
   if defined?(::Sequel)
     AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting sequel' if AppOpticsAPM::Config[:verbose]
-    ::AppOpticsAPM::Util.send_include(::Sequel::Database, ::AppOpticsAPM::Inst::SequelDatabase)
-    ::AppOpticsAPM::Util.send_include(::Sequel::Dataset, ::AppOpticsAPM::Inst::SequelDataset)
+    AppOpticsAPM::Util.send_include(::Sequel::Database, AppOpticsAPM::Inst::SequelDatabase)
+    AppOpticsAPM::Util.send_include(::Sequel::Dataset, AppOpticsAPM::Inst::SequelDataset)
   end
 end

--- a/lib/appoptics_apm/inst/sidekiq-client.rb
+++ b/lib/appoptics_apm/inst/sidekiq-client.rb
@@ -43,13 +43,13 @@ module AppOpticsAPM
   end
 end
 
-if defined?(::Sidekiq) && AppOpticsAPM::Config[:sidekiqclient][:enabled]
-  ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting sidekiq client' if AppOpticsAPM::Config[:verbose]
+if defined?(Sidekiq) && AppOpticsAPM::Config[:sidekiqclient][:enabled]
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting sidekiq client' if AppOpticsAPM::Config[:verbose]
 
-  ::Sidekiq.configure_client do |config|
+  Sidekiq.configure_client do |config|
     config.client_middleware do |chain|
-      ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Adding Sidekiq client middleware' if AppOpticsAPM::Config[:verbose]
-      chain.add ::AppOpticsAPM::SidekiqClient
+      AppOpticsAPM.logger.info '[appoptics_apm/loading] Adding Sidekiq client middleware' if AppOpticsAPM::Config[:verbose]
+      chain.add AppOpticsAPM::SidekiqClient
     end
   end
 end

--- a/lib/appoptics_apm/inst/sidekiq-worker.rb
+++ b/lib/appoptics_apm/inst/sidekiq-worker.rb
@@ -53,13 +53,13 @@ module AppOpticsAPM
   end
 end
 
-if defined?(::Sidekiq) && AppOpticsAPM::Config[:sidekiqworker][:enabled]
-  ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting sidekiq worker' if AppOpticsAPM::Config[:verbose]
+if defined?(Sidekiq) && AppOpticsAPM::Config[:sidekiqworker][:enabled]
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting sidekiq worker' if AppOpticsAPM::Config[:verbose]
 
-  ::Sidekiq.configure_server do |config|
+  Sidekiq.configure_server do |config|
     config.server_middleware do |chain|
-      ::AppOpticsAPM.logger.info '[appoptics_apm/loading] Adding Sidekiq worker middleware' if AppOpticsAPM::Config[:verbose]
-      chain.add ::AppOpticsAPM::SidekiqWorker
+      AppOpticsAPM.logger.info '[appoptics_apm/loading] Adding Sidekiq worker middleware' if AppOpticsAPM::Config[:verbose]
+      chain.add AppOpticsAPM::SidekiqWorker
     end
   end
 end

--- a/lib/appoptics_apm/inst/twitter-cassandra.rb
+++ b/lib/appoptics_apm/inst/twitter-cassandra.rb
@@ -261,14 +261,14 @@ module AppOpticsAPM
 end
 
 # There are two main Cassandra clients for Ruby.  This one from Twitter
-# and the other from datastax.  This one defined ::Cassandra as a class
+# and the other from datastax.  This one defined Cassandra as a class
 # and datastax defines it as a module.  We use this to detect
 # and differentiate between the client in use.
 
-if defined?(::Cassandra) && ::Cassandra.is_a?(Class) && AppOpticsAPM::Config[:cassandra][:enabled]
+if defined?(Cassandra) && Cassandra.is_a?(Class) && AppOpticsAPM::Config[:cassandra][:enabled]
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting cassandra' if AppOpticsAPM::Config[:verbose]
 
-  class ::Cassandra
+  class Cassandra
     include AppOpticsAPM::Inst::Cassandra
 
     [:insert, :remove, :count_columns, :get_columns, :multi_get_columns, :get,

--- a/lib/appoptics_apm/inst/typhoeus.rb
+++ b/lib/appoptics_apm/inst/typhoeus.rb
@@ -82,6 +82,7 @@ module AppOpticsAPM
         kvs[:queued_requests] = queued_requests.count
         kvs[:max_concurrency] = max_concurrency
         kvs[:Async] = 1
+        kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
         # FIXME: Until we figure out a strategy to deal with libcurl internal
         # threading and Ethon's use of easy handles, here we just do a simple

--- a/lib/appoptics_apm/inst/typhoeus.rb
+++ b/lib/appoptics_apm/inst/typhoeus.rb
@@ -7,7 +7,7 @@ module AppOpticsAPM
     module TyphoeusRequestOps
 
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :run, ::Typhoeus::Request::Operations)
+        AppOpticsAPM::Util.method_alias(klass, :run, ::Typhoeus::Request::Operations)
       end
 
       def run_with_appoptics
@@ -28,7 +28,7 @@ module AppOpticsAPM
           kvs = {}
           kvs[:Spec] = 'rsc'
           kvs[:IsService] = 1
-          kvs[:HTTPMethod] = ::AppOpticsAPM::Util.upcase(options[:method])
+          kvs[:HTTPMethod] = AppOpticsAPM::Util.upcase(options[:method])
 
           response = run_without_appoptics
 
@@ -64,7 +64,7 @@ module AppOpticsAPM
 
     module TyphoeusHydraRunnable
       def self.included(klass)
-        ::AppOpticsAPM::Util.method_alias(klass, :run, ::Typhoeus::Hydra)
+        AppOpticsAPM::Util.method_alias(klass, :run, ::Typhoeus::Hydra)
       end
 
       def run_with_appoptics
@@ -101,10 +101,8 @@ module AppOpticsAPM
   end
 end
 
-if AppOpticsAPM::Config[:typhoeus][:enabled]
-  if defined?(::Typhoeus)
-    AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting typhoeus' if AppOpticsAPM::Config[:verbose]
-    ::AppOpticsAPM::Util.send_include(::Typhoeus::Request::Operations, ::AppOpticsAPM::Inst::TyphoeusRequestOps)
-    ::AppOpticsAPM::Util.send_include(::Typhoeus::Hydra, ::AppOpticsAPM::Inst::TyphoeusHydraRunnable)
-  end
+if defined?(Typhoeus) && AppOpticsAPM::Config[:typhoeus][:enabled]
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting typhoeus' if AppOpticsAPM::Config[:verbose]
+  AppOpticsAPM::Util.send_include(Typhoeus::Request::Operations, AppOpticsAPM::Inst::TyphoeusRequestOps)
+  AppOpticsAPM::Util.send_include(Typhoeus::Hydra, AppOpticsAPM::Inst::TyphoeusHydraRunnable)
 end

--- a/lib/appoptics_apm/legacy_method_profiling.rb
+++ b/lib/appoptics_apm/legacy_method_profiling.rb
@@ -51,7 +51,7 @@ module AppOpticsAPMMethodProfiling
                   entry_kvs['File']          = '#{file}'
                   entry_kvs['LineNumber']    = '#{line}'
                   entry_kvs['Args']          = AppOpticsAPM::API.pps(*args) if #{store_args}
-                  entry_kvs.merge!(::AppOpticsAPM::API.get_class_name(self))
+                  entry_kvs.merge!(AppOpticsAPM::API.get_class_name(self))
 
                   AppOpticsAPM::API.log(nil, 'profile_entry', entry_kvs)
 

--- a/lib/appoptics_apm/ruby.rb
+++ b/lib/appoptics_apm/ruby.rb
@@ -31,5 +31,5 @@ module AppOpticsAPM
 end
 
 if AppOpticsAPM.loaded && !AppOpticsAPM.framework?
-  ::AppOpticsAPM::Ruby.load
+  AppOpticsAPM::Ruby.load
 end

--- a/lib/appoptics_apm/sdk/tracing.rb
+++ b/lib/appoptics_apm/sdk/tracing.rb
@@ -94,6 +94,7 @@ module AppOpticsAPM
         opts.delete('TransactionName')
 
         AppOpticsAPM::API.log_entry(span, opts, protect_op)
+        opts[:Backtrace] && opts.delete(:Backtrace) # to avoid sending backtrace twice (faster to check presence here)
         begin
           yield
         rescue Exception => e
@@ -182,6 +183,8 @@ module AppOpticsAPM
         AppOpticsAPM.transaction_name = opts.delete('TransactionName') || opts.delete(:TransactionName)
 
         AppOpticsAPM::API.log_start(span, xtrace, opts)
+        opts[:Backtrace] && opts.delete(:Backtrace) # to avoid sending backtrace twice (faster to check presence here)
+
         # AppOpticsAPM::Event.startTrace creates an Event without an Edge
         exit_evt = AppOpticsAPM::Event.startTrace(AppOpticsAPM::Context.get)
         result = begin

--- a/lib/appoptics_apm/support.rb
+++ b/lib/appoptics_apm/support.rb
@@ -57,8 +57,8 @@ module AppOpticsAPM
     using_rails = defined?(::Rails)
     AppOpticsAPM.logger.warn "Using Rails?: #{yesno(using_rails)}"
     if using_rails
-      AppOpticsAPM.logger.warn "AppOpticsAPM::Rails loaded?: #{yesno(defined?(::AppOpticsAPM::Rails))}"
-      if defined?(::AppOpticsAPM::Rack)
+      AppOpticsAPM.logger.warn "AppOpticsAPM::Rails loaded?: #{yesno(defined?(AppOpticsAPM::Rails))}"
+      if defined?(AppOpticsAPM::Rack)
         AppOpticsAPM.logger.warn "AppOpticsAPM::Rack middleware loaded?: #{yesno(::Rails.configuration.middleware.include? AppOpticsAPM::Rack)}"
       end
     end

--- a/lib/appoptics_apm/thread_local.rb
+++ b/lib/appoptics_apm/thread_local.rb
@@ -7,7 +7,7 @@ module AppOpticsAPM
   #
   # Example usage:
   # module AppOpticsAPMBase
-  #   extend ::AppOpticsAPM::ThreadLocal
+  #   extend AppOpticsAPM::ThreadLocal
   #   thread_local :layer_op
   # end
   module ThreadLocal

--- a/lib/appoptics_apm/util.rb
+++ b/lib/appoptics_apm/util.rb
@@ -265,12 +265,12 @@ module AppOpticsAPM
           platform_info['Force']                        = true
           platform_info['Ruby.Platform.Version']        = RUBY_PLATFORM
           platform_info['Ruby.Version']                 = RUBY_VERSION
-          platform_info['Ruby.AppOptics.Version']    = ::AppOpticsAPM::Version::STRING
+          platform_info['Ruby.AppOptics.Version']    = AppOpticsAPM::Version::STRING
 
           clib_version_file = File.join(Gem::Specification.find_by_name('appoptics_apm').gem_dir, 'ext', 'oboe_metal', 'src', 'VERSION')
           platform_info['Ruby.clib.Version']            = File.read(clib_version_file).chomp
-          platform_info['RubyHeroku.AppOpticsAPM.Version'] = ::AppOpticsAPMHeroku::Version::STRING if defined?(::AppOpticsAPMHeroku)
-          platform_info['Ruby.TraceMode.Version']       = ::AppOpticsAPM::Config[:tracing_mode]
+          platform_info['RubyHeroku.AppOpticsAPM.Version'] = AppOpticsAPMHeroku::Version::STRING if defined?(AppOpticsAPMHeroku)
+          platform_info['Ruby.TraceMode.Version']       = AppOpticsAPM::Config[:tracing_mode]
 
           # Collect up the loaded gems
           if defined?(Gem) && Gem.respond_to?(:loaded_specs)

--- a/lib/oboe/backward_compatibility.rb
+++ b/lib/oboe/backward_compatibility.rb
@@ -11,7 +11,7 @@ module Oboe
   #
   module API
     include AppOpticsAPM::API
-    extend ::AppOpticsAPM::ThreadLocal
+    extend AppOpticsAPM::ThreadLocal
     thread_local :deprecation_notified
 
     def self.method_missing(sym, *args, &blk)
@@ -31,7 +31,7 @@ module Oboe
   # Support for Oboe::Config calls
   #
   module Config
-    extend ::AppOpticsAPM::ThreadLocal
+    extend AppOpticsAPM::ThreadLocal
     thread_local :deprecation_notified
 
     def self.method_missing(sym, *args)
@@ -50,7 +50,7 @@ module Oboe
   # Support for legacy Oboe::Ruby.load calls
   #
   module Ruby
-    extend ::AppOpticsAPM::ThreadLocal
+    extend AppOpticsAPM::ThreadLocal
     thread_local :deprecation_notified
 
     def self.method_missing(sym, *args)

--- a/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
+++ b/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
@@ -183,6 +183,7 @@ if defined?(AppOpticsAPM::Config)
   AppOpticsAPM::Config[:mongo][:enabled] = true
   AppOpticsAPM::Config[:moped][:enabled] = true
   AppOpticsAPM::Config[:nethttp][:enabled] = true
+  AppOpticsAPM::Config[:padrino][:enabled] = true
   AppOpticsAPM::Config[:rack][:enabled] = true
   AppOpticsAPM::Config[:redis][:enabled] = true
   AppOpticsAPM::Config[:resqueclient][:enabled] = true
@@ -191,6 +192,7 @@ if defined?(AppOpticsAPM::Config)
   AppOpticsAPM::Config[:sequel][:enabled] = true
   AppOpticsAPM::Config[:sidekiqclient][:enabled] = true
   AppOpticsAPM::Config[:sidekiqworker][:enabled] = true
+  AppOpticsAPM::Config[:sinatra][:enabled] = true
   AppOpticsAPM::Config[:typhoeus][:enabled] = true
   #
 
@@ -243,6 +245,7 @@ if defined?(AppOpticsAPM::Config)
   AppOpticsAPM::Config[:mongo][:collect_backtraces] = true
   AppOpticsAPM::Config[:moped][:collect_backtraces] = true
   AppOpticsAPM::Config[:nethttp][:collect_backtraces] = true
+  AppOpticsAPM::Config[:padrino][:collect_backtraces] = true
   AppOpticsAPM::Config[:rack][:collect_backtraces] = true
   AppOpticsAPM::Config[:redis][:collect_backtraces] = false
   AppOpticsAPM::Config[:resqueclient][:collect_backtraces] = true
@@ -251,6 +254,7 @@ if defined?(AppOpticsAPM::Config)
   AppOpticsAPM::Config[:sequel][:collect_backtraces] = true
   AppOpticsAPM::Config[:sidekiqclient][:collect_backtraces] = false
   AppOpticsAPM::Config[:sidekiqworker][:collect_backtraces] = false
+  AppOpticsAPM::Config[:sinatra][:collect_backtraces] = true
   AppOpticsAPM::Config[:typhoeus][:collect_backtraces] = false
 
 end

--- a/test/frameworks/grape_test.rb
+++ b/test/frameworks/grape_test.rb
@@ -22,19 +22,19 @@ if defined?(::Grape)
       r.headers.key?('X-Trace').must_equal true
 
       traces = get_all_traces
-      traces.count.must_equal 5
+      traces.count.must_equal 4
 
       validate_outer_layers(traces, 'rack')
 
+      traces[1]['Layer'].must_equal "grape"
       traces[2]['Layer'].must_equal "grape"
-      traces[3]['Layer'].must_equal "grape"
-      traces[2].has_key?('Controller').must_equal true
-      traces[2].has_key?('Action').must_equal true
-      traces[4]['Label'].must_equal "exit"
+      traces[1].has_key?('Controller').must_equal true
+      traces[1].has_key?('Action').must_equal true
+      traces[3]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.headers.key?('X-Trace').must_equal true
-      r.headers['X-Trace'].must_equal traces[4]['X-Trace']
+      r.headers['X-Trace'].must_equal traces[3]['X-Trace']
     end
 
     it "should trace a request to a nested grape stack" do
@@ -46,19 +46,19 @@ if defined?(::Grape)
       r.headers.key?('X-Trace').must_equal true
 
       traces = get_all_traces
-      traces.count.must_equal 5
+      traces.count.must_equal 4
 
       validate_outer_layers(traces, 'rack')
 
+      traces[1]['Layer'].must_equal "grape"
       traces[2]['Layer'].must_equal "grape"
-      traces[3]['Layer'].must_equal "grape"
-      traces[2].has_key?('Controller').must_equal true
-      traces[2].has_key?('Action').must_equal true
-      traces[4]['Label'].must_equal "exit"
+      traces[1].has_key?('Controller').must_equal true
+      traces[1].has_key?('Action').must_equal true
+      traces[3]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.headers.key?('X-Trace').must_equal true
-      r.headers['X-Trace'].must_equal traces[4]['X-Trace']
+      r.headers['X-Trace'].must_equal traces[3]['X-Trace']
     end
 
     it "should trace an error in a nested grape stack" do
@@ -70,31 +70,31 @@ if defined?(::Grape)
       r.headers.key?('X-Trace').must_equal true
 
       traces = get_all_traces
-      traces.count.must_equal 6
+      traces.count.must_equal 5
 
       validate_outer_layers(traces, 'rack')
 
+      traces[1]['Layer'].must_equal "grape"
+      traces[1]['Label'].must_equal "entry"
       traces[2]['Layer'].must_equal "grape"
-      traces[2]['Label'].must_equal "entry"
-      traces[3]['Layer'].must_equal "grape"
-      traces[3]['Label'].must_equal "exit"
-      traces[2].has_key?('Controller').must_equal true
-      traces[2].has_key?('Action').must_equal true
+      traces[2]['Label'].must_equal "exit"
+      traces[1].has_key?('Controller').must_equal true
+      traces[1].has_key?('Action').must_equal true
 
-      traces[4]['Layer'].must_equal "rack"
-      traces[4]['Spec'].must_equal "error"
-      traces[4]['Label'].must_equal "error"
-      traces[4]['ErrorClass'].must_equal "GrapeError"
-      traces[4]['ErrorMsg'].must_equal "This is a error with 'error'!"
-      traces[4].has_key?('Backtrace').must_equal true
+      traces[3]['Layer'].must_equal "rack"
+      traces[3]['Spec'].must_equal "error"
+      traces[3]['Label'].must_equal "error"
+      traces[3]['ErrorClass'].must_equal "GrapeError"
+      traces[3]['ErrorMsg'].must_equal "This is a error with 'error'!"
+      traces[3].has_key?('Backtrace').must_equal true
       traces.select { |trace| trace['Label'] == 'error' }.count.must_equal 1
 
-      traces[5]['Layer'].must_equal "rack"
-      traces[5]['Label'].must_equal "exit"
+      traces[4]['Layer'].must_equal "rack"
+      traces[4]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.headers.key?('X-Trace').must_equal true
-      r.headers['X-Trace'].must_equal traces[5]['X-Trace']
+      r.headers['X-Trace'].must_equal traces[4]['X-Trace']
     end
 
 
@@ -109,22 +109,22 @@ if defined?(::Grape)
       end
 
       traces = get_all_traces
-      traces.count.must_equal 6
+      traces.count.must_equal 5
 
       validate_outer_layers(traces, 'rack')
 
+      traces[1]['Layer'].must_equal "grape"
       traces[2]['Layer'].must_equal "grape"
-      traces[3]['Layer'].must_equal "grape"
-      traces[2].has_key?('Controller').must_equal true
-      traces[2].has_key?('Action').must_equal true
+      traces[1].has_key?('Controller').must_equal true
+      traces[1].has_key?('Action').must_equal true
 
-      traces[4]['Spec'].must_equal "error"
-      traces[4]['Label'].must_equal "error"
-      traces[4]['ErrorClass'].must_equal "Exception"
-      traces[4]['ErrorMsg'].must_equal "This should have http status code 500!"
+      traces[3]['Spec'].must_equal "error"
+      traces[3]['Label'].must_equal "error"
+      traces[3]['ErrorClass'].must_equal "Exception"
+      traces[3]['ErrorMsg'].must_equal "This should have http status code 500!"
       traces.select { |trace| trace['Label'] == 'error' }.count.must_equal 1
 
-      traces[5]['Label'].must_equal "exit"
+      traces[4]['Label'].must_equal "exit"
     end
 
     it "should trace a request with an error" do
@@ -133,7 +133,7 @@ if defined?(::Grape)
       r = get "/error"
 
       traces = get_all_traces
-      traces.count.must_equal 6
+      traces.count.must_equal 5
 
       r.status.must_equal 500
       r.headers.key?('X-Trace').must_equal true
@@ -141,20 +141,20 @@ if defined?(::Grape)
       validate_outer_layers(traces, 'rack')
 
       traces[0]['Layer'].must_equal "rack"
+      traces[1]['Layer'].must_equal "grape"
       traces[2]['Layer'].must_equal "grape"
-      traces[3]['Layer'].must_equal "grape"
-      traces[2].has_key?('Controller').must_equal true
-      traces[2].has_key?('Action').must_equal true
+      traces[1].has_key?('Controller').must_equal true
+      traces[1].has_key?('Action').must_equal true
 
-      traces[4]['Spec'].must_equal "error"
-      traces[4]['Label'].must_equal "error"
-      traces[4]['ErrorClass'].must_equal "GrapeError"
-      traces[4]['ErrorMsg'].must_equal "This is an error with 'error'!"
-      traces[5]['Layer'].must_equal "rack"
+      traces[3]['Spec'].must_equal "error"
+      traces[3]['Label'].must_equal "error"
+      traces[3]['ErrorClass'].must_equal "GrapeError"
+      traces[3]['ErrorMsg'].must_equal "This is an error with 'error'!"
+      traces[4]['Layer'].must_equal "rack"
       traces.select { |trace| trace['Label'] == 'error' }.count.must_equal 1
 
-      traces[5]['Label'].must_equal "exit"
-      traces[5]['Status'].must_equal 500
+      traces[4]['Label'].must_equal "exit"
+      traces[4]['Status'].must_equal 500
     end
 
     it "should report a simple GET path" do

--- a/test/frameworks/padrino_test.rb
+++ b/test/frameworks/padrino_test.rb
@@ -10,6 +10,11 @@ if defined?(::Padrino)
   describe Padrino do
     before do
       clear_all_traces
+      @bt = AppOpticsAPM::Config[:padrino][:collect_backtraces]
+    end
+
+    after do
+      AppOpticsAPM::Config[:padrino][:collect_backtraces] = @bt
     end
 
     it "should trace a request to a simple padrino stack" do
@@ -26,6 +31,8 @@ if defined?(::Padrino)
       traces[1]['Layer'].must_equal "padrino"
       traces[6]['Controller'].must_equal "SimpleDemo"
       traces[7]['Label'].must_equal "exit"
+
+      layer_has_key_once(traces, 'padrino', 'Backtrace')
 
       # Validate the existence of the response header
       r.headers.key?('X-Trace').must_equal true
@@ -49,12 +56,25 @@ if defined?(::Padrino)
 
       traces[2]['Layer'].must_equal "padrino"
 
-      error_trace = traces.find{ |trace| trace['Label'] == 'error' }
+      error_traces = traces.select{ |trace| trace['Label'] == 'error' }
+      error_traces.size.must_equal 1
+
+      error_trace = error_traces[0]
       error_trace['Layer'].must_equal 'padrino'
       error_trace['Spec'].must_equal 'error'
       error_trace.key?('ErrorClass').must_equal true
       error_trace.key?('ErrorMsg').must_equal true
-      traces.select { |trace| trace['Label'] == 'error' }.count.must_equal 1
+    end
+
+    it 'should not report backtraces' do
+      AppOpticsAPM::Config[:padrino][:collect_backtraces] = false
+      @app = SimpleDemo
+
+      r = get "/render"
+
+      traces = get_all_traces
+
+      layer_doesnt_have_key(traces, 'padrino', 'Backtrace')
     end
 
 

--- a/test/frameworks/padrino_test.rb
+++ b/test/frameworks/padrino_test.rb
@@ -19,17 +19,17 @@ if defined?(::Padrino)
 
       traces = get_all_traces
 
-      traces.count.must_equal 9
+      traces.count.must_equal 8
       valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
-      traces[2]['Layer'].must_equal "padrino"
-      traces[7]['Controller'].must_equal "SimpleDemo"
-      traces[8]['Label'].must_equal "exit"
+      traces[1]['Layer'].must_equal "padrino"
+      traces[6]['Controller'].must_equal "SimpleDemo"
+      traces[7]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.headers.key?('X-Trace').must_equal true
-      r.headers['X-Trace'].must_equal traces[8]['X-Trace']
+      r.headers['X-Trace'].must_equal traces[7]['X-Trace']
     end
 
     it "should log an error on exception" do
@@ -43,7 +43,7 @@ if defined?(::Padrino)
       end
 
       traces = get_all_traces
-      traces.count.must_equal 6
+      traces.count.must_equal 5
       valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 

--- a/test/frameworks/rails4x_test.rb
+++ b/test/frameworks/rails4x_test.rb
@@ -37,7 +37,7 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 7
+      traces.count.must_equal 6
       unless defined?(JRUBY_VERSION)
         # We don't test this under JRuby because the Java instrumentation
         # for the DB drivers doesn't use our test reporter hence we won't
@@ -50,29 +50,26 @@ if defined?(::Rails)
       traces[0]['Label'].must_equal "entry"
       traces[0]['URL'].must_equal "/hello/world"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Layer'].must_equal "rails"
+      traces[1]['Label'].must_equal "entry"
+      traces[1]['Controller'].must_equal "HelloController"
+      traces[1]['Action'].must_equal "world"
 
-      traces[2]['Layer'].must_equal "rails"
+      traces[2]['Layer'].must_equal "actionview"
       traces[2]['Label'].must_equal "entry"
-      traces[2]['Controller'].must_equal "HelloController"
-      traces[2]['Action'].must_equal "world"
 
       traces[3]['Layer'].must_equal "actionview"
-      traces[3]['Label'].must_equal "entry"
+      traces[3]['Label'].must_equal "exit"
 
-      traces[4]['Layer'].must_equal "actionview"
+      traces[4]['Layer'].must_equal "rails"
       traces[4]['Label'].must_equal "exit"
 
-      traces[5]['Layer'].must_equal "rails"
+      traces[5]['Layer'].must_equal "rack"
       traces[5]['Label'].must_equal "exit"
-
-      traces[6]['Layer'].must_equal "rack"
-      traces[6]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[6]['X-Trace']
+      r.header['X-Trace'].must_equal traces[5]['X-Trace']
     end
 
     it "should trace rails postgres db calls" do
@@ -85,54 +82,54 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 13
+      traces.count.must_equal 12
       valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
-      traces[3]['Layer'].must_equal "activerecord"
-      traces[3]['Label'].must_equal "entry"
-      traces[3]['Flavor'].must_equal "postgresql"
-      traces[3]['Name'].must_equal "SQL"
-      traces[3].key?('Backtrace').must_equal false
+      traces[2]['Layer'].must_equal "activerecord"
+      traces[2]['Label'].must_equal "entry"
+      traces[2]['Flavor'].must_equal "postgresql"
+      traces[2]['Name'].must_equal "SQL"
+      traces[2].key?('Backtrace').must_equal false
 
       # Use a regular expression to test the SQL string since field order varies between
       # Rails versions
-      match_data = traces[3]['Query']
+      match_data = traces[2]['Query']
       match_data.must_equal("INSERT INTO \"widgets\" (\"name\", \"description\", \"created_at\", \"updated_at\") VALUES ($?, $?, $?, $?) RETURNING \"id\"")
 
-      traces[4]['Layer'].must_equal "activerecord"
-      traces[4]['Label'].must_equal "exit"
+      traces[3]['Layer'].must_equal "activerecord"
+      traces[3]['Label'].must_equal "exit"
 
-      traces[5]['Layer'].must_equal "activerecord"
-      traces[5]['Label'].must_equal "entry"
-      traces[5]['Flavor'].must_equal "postgresql"
+      traces[4]['Layer'].must_equal "activerecord"
+      traces[4]['Label'].must_equal "entry"
+      traces[4]['Flavor'].must_equal "postgresql"
 
       # Some versions of rails adds in another space before the ORDER keyword.
       # Make 2 or more consecutive spaces just 1
-      sql = traces[5]['Query'].gsub(/\s{2,}/, ' ')
+      sql = traces[4]['Query'].gsub(/\s{2,}/, ' ')
       sql.must_equal "SELECT \"widgets\".* FROM \"widgets\" WHERE \"widgets\".\"name\" = $? ORDER BY \"widgets\".\"id\" ASC LIMIT ?"
 
-      traces[5]['Name'].must_equal "Widget Load"
-      traces[5].key?('Backtrace').must_equal false
-      traces[5].key?('QueryArgs').must_equal false
+      traces[4]['Name'].must_equal "Widget Load"
+      traces[4].key?('Backtrace').must_equal false
+      traces[4].key?('QueryArgs').must_equal false
+
+      traces[5]['Layer'].must_equal "activerecord"
+      traces[5]['Label'].must_equal "exit"
 
       traces[6]['Layer'].must_equal "activerecord"
-      traces[6]['Label'].must_equal "exit"
+      traces[6]['Label'].must_equal "entry"
+      traces[6]['Flavor'].must_equal "postgresql"
+      traces[6]['Query'].must_equal "DELETE FROM \"widgets\" WHERE \"widgets\".\"id\" = $?"
+      traces[6]['Name'].must_equal "SQL"
+      traces[6].key?('Backtrace').must_equal false
+      traces[6].key?('QueryArgs').must_equal false
 
       traces[7]['Layer'].must_equal "activerecord"
-      traces[7]['Label'].must_equal "entry"
-      traces[7]['Flavor'].must_equal "postgresql"
-      traces[7]['Query'].must_equal "DELETE FROM \"widgets\" WHERE \"widgets\".\"id\" = $?"
-      traces[7]['Name'].must_equal "SQL"
-      traces[7].key?('Backtrace').must_equal false
-      traces[7].key?('QueryArgs').must_equal false
-
-      traces[8]['Layer'].must_equal "activerecord"
-      traces[8]['Label'].must_equal "exit"
+      traces[7]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[12]['X-Trace']
+      r.header['X-Trace'].must_equal traces[11]['X-Trace']
     end
 
     it "should trace rails mysql db calls" do
@@ -147,69 +144,69 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 17
+      traces.count.must_equal 16
       valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
+      traces[2]['Layer'].must_equal "activerecord"
+      traces[2]['Label'].must_equal "entry"
+      traces[2]['Flavor'].must_equal "mysql"
+      traces[2]['Query'].must_equal "BEGIN"
+      traces[2].key?('Backtrace').must_equal false
+
       traces[3]['Layer'].must_equal "activerecord"
-      traces[3]['Label'].must_equal "entry"
-      traces[3]['Flavor'].must_equal "mysql"
-      traces[3]['Query'].must_equal "BEGIN"
-      traces[3].key?('Backtrace').must_equal false
+      traces[3]['Label'].must_equal "exit"
 
       traces[4]['Layer'].must_equal "activerecord"
-      traces[4]['Label'].must_equal "exit"
+      traces[4]['Label'].must_equal "entry"
+      traces[4]['Flavor'].must_equal "mysql"
+      traces[4]['Query'].must_equal "INSERT INTO `widgets` (`name`, `description`, `created_at`, `updated_at`) VALUES (?, ?, ?, ?)"
+      traces[4]['Name'].must_equal "SQL"
+      traces[4].key?('Backtrace').must_equal false
+      traces[4].key?('QueryArgs').must_equal true
 
       traces[5]['Layer'].must_equal "activerecord"
-      traces[5]['Label'].must_equal "entry"
-      traces[5]['Flavor'].must_equal "mysql"
-      traces[5]['Query'].must_equal "INSERT INTO `widgets` (`name`, `description`, `created_at`, `updated_at`) VALUES (?, ?, ?, ?)"
-      traces[5]['Name'].must_equal "SQL"
-      traces[5].key?('Backtrace').must_equal false
-      traces[5].key?('QueryArgs').must_equal true
+      traces[5]['Label'].must_equal "exit"
 
       traces[6]['Layer'].must_equal "activerecord"
-      traces[6]['Label'].must_equal "exit"
+      traces[6]['Label'].must_equal "entry"
+      traces[6]['Flavor'].must_equal "mysql"
+      traces[6]['Query'].must_equal "COMMIT"
+      traces[6].key?('Backtrace').must_equal false
 
       traces[7]['Layer'].must_equal "activerecord"
-      traces[7]['Label'].must_equal "entry"
-      traces[7]['Flavor'].must_equal "mysql"
-      traces[7]['Query'].must_equal "COMMIT"
-      traces[7].key?('Backtrace').must_equal false
+      traces[7]['Label'].must_equal "exit"
 
       traces[8]['Layer'].must_equal "activerecord"
-      traces[8]['Label'].must_equal "exit"
-
-      traces[9]['Layer'].must_equal "activerecord"
-      traces[9]['Label'].must_equal "entry"
-      traces[9]['Flavor'].must_equal "mysql"
-      traces[9]['Name'].must_equal "Widget Load"
-      traces[9].key?('Backtrace').must_equal false
+      traces[8]['Label'].must_equal "entry"
+      traces[8]['Flavor'].must_equal "mysql"
+      traces[8]['Name'].must_equal "Widget Load"
+      traces[8].key?('Backtrace').must_equal false
 
       # Some versions of rails adds in another space before the ORDER keyword.
       # Make 2 or more consecutive spaces just 1
-      sql = traces[9]['Query'].gsub(/\s{2,}/, ' ')
+      sql = traces[8]['Query'].gsub(/\s{2,}/, ' ')
       sql.must_equal "SELECT `widgets`.* FROM `widgets` WHERE `widgets`.`name` = ? ORDER BY `widgets`.`id` ASC LIMIT 1"
 
+      traces[9]['Layer'].must_equal "activerecord"
+      traces[9]['Label'].must_equal "exit"
+
       traces[10]['Layer'].must_equal "activerecord"
-      traces[10]['Label'].must_equal "exit"
+      traces[10]['Label'].must_equal "entry"
+      traces[10]['Flavor'].must_equal "mysql"
+      traces[10]['Name'].must_equal "SQL"
+      traces[10].key?('Backtrace').must_equal false
+      traces[10].key?('QueryArgs').must_equal true
+      traces[10]['Query'].must_equal "DELETE FROM `widgets` WHERE `widgets`.`id` = ?"
 
       traces[11]['Layer'].must_equal "activerecord"
-      traces[11]['Label'].must_equal "entry"
-      traces[11]['Flavor'].must_equal "mysql"
-      traces[11]['Name'].must_equal "SQL"
-      traces[11].key?('Backtrace').must_equal false
-      traces[11].key?('QueryArgs').must_equal true
-      traces[11]['Query'].must_equal "DELETE FROM `widgets` WHERE `widgets`.`id` = ?"
+      traces[11]['Label'].must_equal "exit"
 
-      traces[12]['Layer'].must_equal "activerecord"
-      traces[12]['Label'].must_equal "exit"
-
-      traces[13]['Layer'].must_equal "actionview"
-      traces[13]['Label'].must_equal "entry"
+      traces[12]['Layer'].must_equal "actionview"
+      traces[12]['Label'].must_equal "entry"
 
       # Validate the existence of the response header
-      r['X-Trace'].must_equal traces[16]['X-Trace']
+      r['X-Trace'].must_equal traces[15]['X-Trace']
     end
 
     it "should trace rails mysql db calls with sanitize sql" do
@@ -224,69 +221,69 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 17
+      traces.count.must_equal 16
       valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
+      traces[2]['Layer'].must_equal "activerecord"
+      traces[2]['Label'].must_equal "entry"
+      traces[2]['Flavor'].must_equal "mysql"
+      traces[2]['Query'].must_equal "BEGIN"
+      traces[2].key?('Backtrace').must_equal false
+
       traces[3]['Layer'].must_equal "activerecord"
-      traces[3]['Label'].must_equal "entry"
-      traces[3]['Flavor'].must_equal "mysql"
-      traces[3]['Query'].must_equal "BEGIN"
-      traces[3].key?('Backtrace').must_equal false
+      traces[3]['Label'].must_equal "exit"
 
       traces[4]['Layer'].must_equal "activerecord"
-      traces[4]['Label'].must_equal "exit"
+      traces[4]['Label'].must_equal "entry"
+      traces[4]['Flavor'].must_equal "mysql"
+      traces[4]['Query'].must_equal "INSERT INTO `widgets` (`name`, `description`, `created_at`, `updated_at`) VALUES (?, ?, ?, ?)"
+      traces[4]['Name'].must_equal "SQL"
+      traces[4].key?('Backtrace').must_equal false
+      traces[4].key?('QueryArgs').must_equal false
 
       traces[5]['Layer'].must_equal "activerecord"
-      traces[5]['Label'].must_equal "entry"
-      traces[5]['Flavor'].must_equal "mysql"
-      traces[5]['Query'].must_equal "INSERT INTO `widgets` (`name`, `description`, `created_at`, `updated_at`) VALUES (?, ?, ?, ?)"
-      traces[5]['Name'].must_equal "SQL"
-      traces[5].key?('Backtrace').must_equal false
-      traces[5].key?('QueryArgs').must_equal false
+      traces[5]['Label'].must_equal "exit"
 
       traces[6]['Layer'].must_equal "activerecord"
-      traces[6]['Label'].must_equal "exit"
+      traces[6]['Label'].must_equal "entry"
+      traces[6]['Flavor'].must_equal "mysql"
+      traces[6]['Query'].must_equal "COMMIT"
+      traces[6].key?('Backtrace').must_equal false
 
       traces[7]['Layer'].must_equal "activerecord"
-      traces[7]['Label'].must_equal "entry"
-      traces[7]['Flavor'].must_equal "mysql"
-      traces[7]['Query'].must_equal "COMMIT"
-      traces[7].key?('Backtrace').must_equal false
+      traces[7]['Label'].must_equal "exit"
 
       traces[8]['Layer'].must_equal "activerecord"
-      traces[8]['Label'].must_equal "exit"
-
-      traces[9]['Layer'].must_equal "activerecord"
-      traces[9]['Label'].must_equal "entry"
-      traces[9]['Flavor'].must_equal "mysql"
-      traces[9]['Name'].must_equal "Widget Load"
-      traces[9].key?('Backtrace').must_equal false
+      traces[8]['Label'].must_equal "entry"
+      traces[8]['Flavor'].must_equal "mysql"
+      traces[8]['Name'].must_equal "Widget Load"
+      traces[8].key?('Backtrace').must_equal false
 
       # Some versions of rails adds in another space before the ORDER keyword.
       # Make 2 or more consecutive spaces just 1
-      sql = traces[9]['Query'].gsub(/\s{2,}/, ' ')
+      sql = traces[8]['Query'].gsub(/\s{2,}/, ' ')
       sql.must_equal "SELECT `widgets`.* FROM `widgets` WHERE `widgets`.`name` = ? ORDER BY `widgets`.`id` ASC LIMIT ?"
 
+      traces[9]['Layer'].must_equal "activerecord"
+      traces[9]['Label'].must_equal "exit"
+
       traces[10]['Layer'].must_equal "activerecord"
-      traces[10]['Label'].must_equal "exit"
+      traces[10]['Label'].must_equal "entry"
+      traces[10]['Flavor'].must_equal "mysql"
+      traces[10]['Name'].must_equal "SQL"
+      traces[10].key?('Backtrace').must_equal false
+      traces[10].key?('QueryArgs').must_equal false
+      traces[10]['Query'].must_equal "DELETE FROM `widgets` WHERE `widgets`.`id` = ?"
 
       traces[11]['Layer'].must_equal "activerecord"
-      traces[11]['Label'].must_equal "entry"
-      traces[11]['Flavor'].must_equal "mysql"
-      traces[11]['Name'].must_equal "SQL"
-      traces[11].key?('Backtrace').must_equal false
-      traces[11].key?('QueryArgs').must_equal false
-      traces[11]['Query'].must_equal "DELETE FROM `widgets` WHERE `widgets`.`id` = ?"
+      traces[11]['Label'].must_equal "exit"
 
-      traces[12]['Layer'].must_equal "activerecord"
-      traces[12]['Label'].must_equal "exit"
-
-      traces[13]['Layer'].must_equal "actionview"
-      traces[13]['Label'].must_equal "entry"
+      traces[12]['Layer'].must_equal "actionview"
+      traces[12]['Label'].must_equal "entry"
 
       # Validate the existence of the response header
-      r['X-Trace'].must_equal traces[16]['X-Trace']
+      r['X-Trace'].must_equal traces[15]['X-Trace']
     end
 
     it "should trace rails mysql2 db calls" do
@@ -301,50 +298,50 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 13
+      traces.count.must_equal 12
       valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
-      traces[3]['Layer'].must_equal "activerecord"
-      traces[3]['Label'].must_equal "entry"
-      traces[3]['Flavor'].must_equal "mysql"
+      traces[2]['Layer'].must_equal "activerecord"
+      traces[2]['Label'].must_equal "entry"
+      traces[2]['Flavor'].must_equal "mysql"
 
       # Replace the datestamps with xxx to make testing easier
-      traces[3]['Query'].gsub!(/\d\d\d\d-\d\d-\d\d\s\d\d:\d\d:\d\d/, 'xxx')
-      traces[3]['Query'].must_equal "INSERT INTO `widgets` (`name`, `description`, `created_at`, `updated_at`) VALUES ('blah', 'This is an amazing widget.', 'xxx', 'xxx')"
+      traces[2]['Query'].gsub!(/\d\d\d\d-\d\d-\d\d\s\d\d:\d\d:\d\d/, 'xxx')
+      traces[2]['Query'].must_equal "INSERT INTO `widgets` (`name`, `description`, `created_at`, `updated_at`) VALUES ('blah', 'This is an amazing widget.', 'xxx', 'xxx')"
 
-      traces[3]['Name'].must_equal "SQL"
-      traces[3].key?('Backtrace').must_equal false
-      traces[3].key?('QueryArgs').must_equal true
+      traces[2]['Name'].must_equal "SQL"
+      traces[2].key?('Backtrace').must_equal false
+      traces[2].key?('QueryArgs').must_equal true
+
+      traces[3]['Layer'].must_equal "activerecord"
+      traces[3]['Label'].must_equal "exit"
 
       traces[4]['Layer'].must_equal "activerecord"
-      traces[4]['Label'].must_equal "exit"
+      traces[4]['Label'].must_equal "entry"
+      traces[4]['Flavor'].must_equal "mysql"
+      traces[4]['Query'].must_equal "SELECT  `widgets`.* FROM `widgets` WHERE `widgets`.`name` = 'blah'  ORDER BY `widgets`.`id` ASC LIMIT 1"
+      traces[4]['Name'].must_equal "Widget Load"
+      traces[4].key?('Backtrace').must_equal false
+      traces[4].key?('QueryArgs').must_equal true
 
       traces[5]['Layer'].must_equal "activerecord"
-      traces[5]['Label'].must_equal "entry"
-      traces[5]['Flavor'].must_equal "mysql"
-      traces[5]['Query'].must_equal "SELECT  `widgets`.* FROM `widgets` WHERE `widgets`.`name` = 'blah'  ORDER BY `widgets`.`id` ASC LIMIT 1"
-      traces[5]['Name'].must_equal "Widget Load"
-      traces[5].key?('Backtrace').must_equal false
-      traces[5].key?('QueryArgs').must_equal true
+      traces[5]['Label'].must_equal "exit"
 
       traces[6]['Layer'].must_equal "activerecord"
-      traces[6]['Label'].must_equal "exit"
+      traces[6]['Label'].must_equal "entry"
+      traces[6]['Flavor'].must_equal "mysql"
+      traces[6]['Name'].must_equal "SQL"
+      traces[6].key?('Backtrace').must_equal false
 
-      traces[7]['Layer'].must_equal "activerecord"
-      traces[7]['Label'].must_equal "entry"
-      traces[7]['Flavor'].must_equal "mysql"
-      traces[7]['Name'].must_equal "SQL"
-      traces[7].key?('Backtrace').must_equal false
-
-      sql = traces[7]['Query'].gsub(/\d+/, 'xxx')
+      sql = traces[6]['Query'].gsub(/\d+/, 'xxx')
       sql.must_equal "DELETE FROM `widgets` WHERE `widgets`.`id` = xxx"
 
-      traces[8]['Layer'].must_equal "activerecord"
-      traces[8]['Label'].must_equal "exit"
+      traces[7]['Layer'].must_equal "activerecord"
+      traces[7]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
-      r['X-Trace'].must_equal traces[12]['X-Trace']
+      r['X-Trace'].must_equal traces[11]['X-Trace']
     end
 
     it "should trace rails mysql2 db calls with santize sql" do
@@ -359,48 +356,48 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 13
+      traces.count.must_equal 12
       valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
-      traces[3]['Layer'].must_equal "activerecord"
-      traces[3]['Label'].must_equal "entry"
-      traces[3]['Flavor'].must_equal "mysql"
+      traces[2]['Layer'].must_equal "activerecord"
+      traces[2]['Label'].must_equal "entry"
+      traces[2]['Flavor'].must_equal "mysql"
 
       # Replace the datestamps with xxx to make testing easier
-      traces[3]['Query'].must_equal "INSERT INTO `widgets` (`name`, `description`, `created_at`, `updated_at`) VALUES (?, ?, ?, ?)"
+      traces[2]['Query'].must_equal "INSERT INTO `widgets` (`name`, `description`, `created_at`, `updated_at`) VALUES (?, ?, ?, ?)"
 
-      traces[3]['Name'].must_equal "SQL"
-      traces[3].key?('Backtrace').must_equal false
-      traces[3].key?('QueryArgs').must_equal false
+      traces[2]['Name'].must_equal "SQL"
+      traces[2].key?('Backtrace').must_equal false
+      traces[2].key?('QueryArgs').must_equal false
+
+      traces[3]['Layer'].must_equal "activerecord"
+      traces[3]['Label'].must_equal "exit"
 
       traces[4]['Layer'].must_equal "activerecord"
-      traces[4]['Label'].must_equal "exit"
+      traces[4]['Label'].must_equal "entry"
+      traces[4]['Flavor'].must_equal "mysql"
+      traces[4]['Query'].must_equal "SELECT  `widgets`.* FROM `widgets` WHERE `widgets`.`name` = ?  ORDER BY `widgets`.`id` ASC LIMIT ?"
+      traces[4]['Name'].must_equal "Widget Load"
+      traces[4].key?('Backtrace').must_equal false
+      traces[4].key?('QueryArgs').must_equal false
 
       traces[5]['Layer'].must_equal "activerecord"
-      traces[5]['Label'].must_equal "entry"
-      traces[5]['Flavor'].must_equal "mysql"
-      traces[5]['Query'].must_equal "SELECT  `widgets`.* FROM `widgets` WHERE `widgets`.`name` = ?  ORDER BY `widgets`.`id` ASC LIMIT ?"
-      traces[5]['Name'].must_equal "Widget Load"
-      traces[5].key?('Backtrace').must_equal false
-      traces[5].key?('QueryArgs').must_equal false
+      traces[5]['Label'].must_equal "exit"
 
       traces[6]['Layer'].must_equal "activerecord"
-      traces[6]['Label'].must_equal "exit"
+      traces[6]['Label'].must_equal "entry"
+      traces[6]['Flavor'].must_equal "mysql"
+      traces[6]['Name'].must_equal "SQL"
+      traces[6].key?('Backtrace').must_equal false
+
+      traces[6]['Query'].must_equal "DELETE FROM `widgets` WHERE `widgets`.`id` = ?"
 
       traces[7]['Layer'].must_equal "activerecord"
-      traces[7]['Label'].must_equal "entry"
-      traces[7]['Flavor'].must_equal "mysql"
-      traces[7]['Name'].must_equal "SQL"
-      traces[7].key?('Backtrace').must_equal false
-
-      traces[7]['Query'].must_equal "DELETE FROM `widgets` WHERE `widgets`.`id` = ?"
-
-      traces[8]['Layer'].must_equal "activerecord"
-      traces[8]['Label'].must_equal "exit"
+      traces[7]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
-      r['X-Trace'].must_equal traces[12]['X-Trace']
+      r['X-Trace'].must_equal traces[11]['X-Trace']
     end
 
     it "should trace a request to a rails metal stack" do
@@ -409,7 +406,7 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 5
+      traces.count.must_equal 4
       unless defined?(JRUBY_VERSION)
         # We don't test this under JRuby because the Java instrumentation
         # for the DB drivers doesn't use our test reporter hence we won't
@@ -422,26 +419,23 @@ if defined?(::Rails)
       traces[0]['Label'].must_equal "entry"
       traces[0]['URL'].must_equal "/hello/metal"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Label'].must_equal "profile_entry"
+      traces[1]['Language'].must_equal "ruby"
+      traces[1]['ProfileName'].must_equal "world"
+      traces[1]['MethodName'].must_equal "world"
+      traces[1]['Class'].must_equal "FerroController"
+      traces[1]['Controller'].must_equal "FerroController"
+      traces[1]['Action'].must_equal "world"
 
-      traces[2]['Label'].must_equal "profile_entry"
+      traces[2]['Label'].must_equal "profile_exit"
       traces[2]['Language'].must_equal "ruby"
       traces[2]['ProfileName'].must_equal "world"
-      traces[2]['MethodName'].must_equal "world"
-      traces[2]['Class'].must_equal "FerroController"
-      traces[2]['Controller'].must_equal "FerroController"
-      traces[2]['Action'].must_equal "world"
 
-      traces[3]['Label'].must_equal "profile_exit"
-      traces[3]['Language'].must_equal "ruby"
-      traces[3]['ProfileName'].must_equal "world"
-
-      traces[4]['Layer'].must_equal "rack"
-      traces[4]['Label'].must_equal "exit"
+      traces[3]['Layer'].must_equal "rack"
+      traces[3]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
-      r['X-Trace'].must_equal traces[4]['X-Trace']
+      r['X-Trace'].must_equal traces[3]['X-Trace']
     end
 
     it "should collect backtraces when true" do
@@ -452,7 +446,7 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 7
+      traces.count.must_equal 6
       unless defined?(JRUBY_VERSION)
         # We don't test this under JRuby because the Java instrumentation
         # for the DB drivers doesn't use our test reporter hence we won't
@@ -465,29 +459,26 @@ if defined?(::Rails)
       traces[0]['Label'].must_equal "entry"
       traces[0]['URL'].must_equal "/hello/world"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Layer'].must_equal "rails"
+      traces[1]['Label'].must_equal "entry"
+      traces[1]['Controller'].must_equal "HelloController"
+      traces[1]['Action'].must_equal "world"
+      traces[1].key?('Backtrace').must_equal true
 
-      traces[2]['Layer'].must_equal "rails"
+      traces[2]['Layer'].must_equal "actionview"
       traces[2]['Label'].must_equal "entry"
-      traces[2]['Controller'].must_equal "HelloController"
-      traces[2]['Action'].must_equal "world"
-      traces[2].key?('Backtrace').must_equal true
 
       traces[3]['Layer'].must_equal "actionview"
-      traces[3]['Label'].must_equal "entry"
+      traces[3]['Label'].must_equal "exit"
 
-      traces[4]['Layer'].must_equal "actionview"
+      traces[4]['Layer'].must_equal "rails"
       traces[4]['Label'].must_equal "exit"
 
-      traces[5]['Layer'].must_equal "rails"
+      traces[5]['Layer'].must_equal "rack"
       traces[5]['Label'].must_equal "exit"
 
-      traces[6]['Layer'].must_equal "rack"
-      traces[6]['Label'].must_equal "exit"
-
       # Validate the existence of the response header
-      r['X-Trace'].must_equal traces[6]['X-Trace']
+      r['X-Trace'].must_equal traces[5]['X-Trace']
     end
 
     it "should NOT collect backtraces when false" do
@@ -498,7 +489,7 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 7
+      traces.count.must_equal 6
       unless defined?(JRUBY_VERSION)
         # We don't test this under JRuby because the Java instrumentation
         # for the DB drivers doesn't use our test reporter hence we won't
@@ -511,29 +502,26 @@ if defined?(::Rails)
       traces[0]['Label'].must_equal "entry"
       traces[0]['URL'].must_equal "/hello/world"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Layer'].must_equal "rails"
+      traces[1]['Label'].must_equal "entry"
+      traces[1]['Controller'].must_equal "HelloController"
+      traces[1]['Action'].must_equal "world"
+      traces[1].key?('Backtrace').must_equal false
 
-      traces[2]['Layer'].must_equal "rails"
+      traces[2]['Layer'].must_equal "actionview"
       traces[2]['Label'].must_equal "entry"
-      traces[2]['Controller'].must_equal "HelloController"
-      traces[2]['Action'].must_equal "world"
-      traces[2].key?('Backtrace').must_equal false
 
       traces[3]['Layer'].must_equal "actionview"
-      traces[3]['Label'].must_equal "entry"
+      traces[3]['Label'].must_equal "exit"
 
-      traces[4]['Layer'].must_equal "actionview"
+      traces[4]['Layer'].must_equal "rails"
       traces[4]['Label'].must_equal "exit"
 
-      traces[5]['Layer'].must_equal "rails"
+      traces[5]['Layer'].must_equal "rack"
       traces[5]['Label'].must_equal "exit"
 
-      traces[6]['Layer'].must_equal "rack"
-      traces[6]['Label'].must_equal "exit"
-
       # Validate the existence of the response header
-      r['X-Trace'].must_equal traces[6]['X-Trace']
+      r['X-Trace'].must_equal traces[5]['X-Trace']
     end
 
     it "should NOT trace when tracing is set to :never" do

--- a/test/frameworks/rails5x_api_test.rb
+++ b/test/frameworks/rails5x_api_test.rb
@@ -30,7 +30,7 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 7
+      traces.count.must_equal 6
       unless defined?(JRUBY_VERSION)
         # We don't test this under JRuby because the Java instrumentation
         # for the DB drivers doesn't use our test reporter hence we won't
@@ -43,33 +43,73 @@ if defined?(::Rails)
       traces[0]['Label'].must_equal "entry"
       traces[0]['URL'].must_equal "/monkey/hello"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Layer'].must_equal "rails-api"
+      traces[1]['Label'].must_equal "entry"
+      traces[1]['Controller'].must_equal "MonkeyController"
+      traces[1]['Action'].must_equal "hello"
 
-      traces[2]['Layer'].must_equal "rails-api"
+      traces[2]['Layer'].must_equal "actionview"
       traces[2]['Label'].must_equal "entry"
-      traces[2]['Controller'].must_equal "MonkeyController"
-      traces[2]['Action'].must_equal "hello"
 
       traces[3]['Layer'].must_equal "actionview"
-      traces[3]['Label'].must_equal "entry"
+      traces[3]['Label'].must_equal "exit"
 
-      traces[4]['Layer'].must_equal "actionview"
+      traces[4]['Layer'].must_equal "rails-api"
       traces[4]['Label'].must_equal "exit"
 
-      traces[5]['Layer'].must_equal "rails-api"
+      traces[5]['Layer'].must_equal "rack"
       traces[5]['Label'].must_equal "exit"
-
-      traces[6]['Layer'].must_equal "rack"
-      traces[6]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[6]['X-Trace']
+      r.header['X-Trace'].must_equal traces[5]['X-Trace']
     end
 
     it "should capture errors" do
       uri = URI.parse('http://127.0.0.1:8150/monkey/error')
+      r = Net::HTTP.get_response(uri)
+
+      traces = get_all_traces
+
+      traces.count.must_equal 5
+      unless defined?(JRUBY_VERSION)
+        # We don't test this under JRuby because the Java instrumentation
+        # for the DB drivers doesn't use our test reporter hence we won't
+        # see all trace events. :-(  To be improved.
+        valid_edges?(traces).must_equal true
+      end
+      validate_outer_layers(traces, 'rack')
+
+      traces[0]['Layer'].must_equal "rack"
+      traces[0]['Label'].must_equal "entry"
+      traces[0]['URL'].must_equal "/monkey/error"
+
+      traces[1]['Layer'].must_equal "rails-api"
+      traces[1]['Label'].must_equal "entry"
+      traces[1]['Controller'].must_equal "MonkeyController"
+      traces[1]['Action'].must_equal "error"
+
+      traces[2]['Spec'].must_equal "error"
+      traces[2]['Label'].must_equal "error"
+      traces[2]['ErrorClass'].must_equal "RuntimeError"
+      traces[2]['ErrorMsg'].must_equal "Rails API fake error from controller"
+      traces.select { |trace| trace['Label'] == 'error' }.count.must_equal 1
+
+      traces[3]['Layer'].must_equal "rails-api"
+      traces[3]['Label'].must_equal "exit"
+
+      traces[4]['Layer'].must_equal "rack"
+      traces[4]['Label'].must_equal "exit"
+
+      # Validate the existence of the response header
+      r.header.key?('X-Trace').must_equal true
+      r.header['X-Trace'].must_equal traces[4]['X-Trace']
+    end
+
+    it "should collect backtraces when true" do
+      AppOpticsAPM::Config[:action_controller_api][:collect_backtraces] = true
+
+      uri = URI.parse('http://127.0.0.1:8150/monkey/hello')
       r = Net::HTTP.get_response(uri)
 
       traces = get_all_traces
@@ -85,21 +125,19 @@ if defined?(::Rails)
 
       traces[0]['Layer'].must_equal "rack"
       traces[0]['Label'].must_equal "entry"
-      traces[0]['URL'].must_equal "/monkey/error"
+      traces[0]['URL'].must_equal "/monkey/hello"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Layer'].must_equal "rails-api"
+      traces[1]['Label'].must_equal "entry"
+      traces[1]['Controller'].must_equal "MonkeyController"
+      traces[1]['Action'].must_equal "hello"
+      traces[1].key?('Backtrace').must_equal true
 
-      traces[2]['Layer'].must_equal "rails-api"
+      traces[2]['Layer'].must_equal "actionview"
       traces[2]['Label'].must_equal "entry"
-      traces[2]['Controller'].must_equal "MonkeyController"
-      traces[2]['Action'].must_equal "error"
 
-      traces[3]['Spec'].must_equal "error"
-      traces[3]['Label'].must_equal "error"
-      traces[3]['ErrorClass'].must_equal "RuntimeError"
-      traces[3]['ErrorMsg'].must_equal "Rails API fake error from controller"
-      traces.select { |trace| trace['Label'] == 'error' }.count.must_equal 1
+      traces[3]['Layer'].must_equal "actionview"
+      traces[3]['Label'].must_equal "exit"
 
       traces[4]['Layer'].must_equal "rails-api"
       traces[4]['Label'].must_equal "exit"
@@ -112,53 +150,6 @@ if defined?(::Rails)
       r.header['X-Trace'].must_equal traces[5]['X-Trace']
     end
 
-    it "should collect backtraces when true" do
-      AppOpticsAPM::Config[:action_controller_api][:collect_backtraces] = true
-
-      uri = URI.parse('http://127.0.0.1:8150/monkey/hello')
-      r = Net::HTTP.get_response(uri)
-
-      traces = get_all_traces
-
-      traces.count.must_equal 7
-      unless defined?(JRUBY_VERSION)
-        # We don't test this under JRuby because the Java instrumentation
-        # for the DB drivers doesn't use our test reporter hence we won't
-        # see all trace events. :-(  To be improved.
-        valid_edges?(traces).must_equal true
-      end
-      validate_outer_layers(traces, 'rack')
-
-      traces[0]['Layer'].must_equal "rack"
-      traces[0]['Label'].must_equal "entry"
-      traces[0]['URL'].must_equal "/monkey/hello"
-
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
-
-      traces[2]['Layer'].must_equal "rails-api"
-      traces[2]['Label'].must_equal "entry"
-      traces[2]['Controller'].must_equal "MonkeyController"
-      traces[2]['Action'].must_equal "hello"
-      traces[2].key?('Backtrace').must_equal true
-
-      traces[3]['Layer'].must_equal "actionview"
-      traces[3]['Label'].must_equal "entry"
-
-      traces[4]['Layer'].must_equal "actionview"
-      traces[4]['Label'].must_equal "exit"
-
-      traces[5]['Layer'].must_equal "rails-api"
-      traces[5]['Label'].must_equal "exit"
-
-      traces[6]['Layer'].must_equal "rack"
-      traces[6]['Label'].must_equal "exit"
-
-      # Validate the existence of the response header
-      r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[6]['X-Trace']
-    end
-
     it "should NOT collect backtraces when false" do
       AppOpticsAPM::Config[:action_controller_api][:collect_backtraces] = false
 
@@ -167,7 +158,7 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 7
+      traces.count.must_equal 6
       unless defined?(JRUBY_VERSION)
         # We don't test this under JRuby because the Java instrumentation
         # for the DB drivers doesn't use our test reporter hence we won't
@@ -180,30 +171,27 @@ if defined?(::Rails)
       traces[0]['Label'].must_equal "entry"
       traces[0]['URL'].must_equal "/monkey/hello"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Layer'].must_equal "rails-api"
+      traces[1]['Label'].must_equal "entry"
+      traces[1]['Controller'].must_equal "MonkeyController"
+      traces[1]['Action'].must_equal "hello"
+      traces[1].key?('Backtrace').must_equal false
 
-      traces[2]['Layer'].must_equal "rails-api"
+      traces[2]['Layer'].must_equal "actionview"
       traces[2]['Label'].must_equal "entry"
-      traces[2]['Controller'].must_equal "MonkeyController"
-      traces[2]['Action'].must_equal "hello"
-      traces[2].key?('Backtrace').must_equal false
 
       traces[3]['Layer'].must_equal "actionview"
-      traces[3]['Label'].must_equal "entry"
+      traces[3]['Label'].must_equal "exit"
 
-      traces[4]['Layer'].must_equal "actionview"
+      traces[4]['Layer'].must_equal "rails-api"
       traces[4]['Label'].must_equal "exit"
 
-      traces[5]['Layer'].must_equal "rails-api"
+      traces[5]['Layer'].must_equal "rack"
       traces[5]['Label'].must_equal "exit"
-
-      traces[6]['Layer'].must_equal "rack"
-      traces[6]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[6]['X-Trace']
+      r.header['X-Trace'].must_equal traces[5]['X-Trace']
     end
 
     require_relative "rails_shared_tests"

--- a/test/frameworks/rails5x_test.rb
+++ b/test/frameworks/rails5x_test.rb
@@ -38,7 +38,7 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 7
+      traces.count.must_equal 6
       unless defined?(JRUBY_VERSION)
         # We don't test this under JRuby because the Java instrumentation
         # for the DB drivers doesn't use our test reporter hence we won't
@@ -51,29 +51,26 @@ if defined?(::Rails)
       traces[0]['Label'].must_equal "entry"
       traces[0]['URL'].must_equal "/hello/world"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Layer'].must_equal "rails"
+      traces[1]['Label'].must_equal "entry"
+      traces[1]['Controller'].must_equal "HelloController"
+      traces[1]['Action'].must_equal "world"
 
-      traces[2]['Layer'].must_equal "rails"
+      traces[2]['Layer'].must_equal "actionview"
       traces[2]['Label'].must_equal "entry"
-      traces[2]['Controller'].must_equal "HelloController"
-      traces[2]['Action'].must_equal "world"
 
       traces[3]['Layer'].must_equal "actionview"
-      traces[3]['Label'].must_equal "entry"
+      traces[3]['Label'].must_equal "exit"
 
-      traces[4]['Layer'].must_equal "actionview"
+      traces[4]['Layer'].must_equal "rails"
       traces[4]['Label'].must_equal "exit"
 
-      traces[5]['Layer'].must_equal "rails"
+      traces[5]['Layer'].must_equal "rack"
       traces[5]['Label'].must_equal "exit"
-
-      traces[6]['Layer'].must_equal "rack"
-      traces[6]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[6]['X-Trace']
+      r.header['X-Trace'].must_equal traces[5]['X-Trace']
     end
 
     # Different behavior in Rails >= 5.2.0
@@ -88,45 +85,45 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 13
+      traces.count.must_equal 12
       valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
+      traces[2]['Layer'].must_equal "activerecord"
+      traces[2]['Label'].must_equal "entry"
+      traces[2]['Flavor'].must_equal "postgresql"
+      traces[2]['Query'].must_equal "INSERT INTO \"widgets\" (\"name\", \"description\", \"created_at\", \"updated_at\") VALUES ($?, $?, $?, $?) RETURNING \"id\""
+      traces[2]['Name'].must_equal Rails.version < '5.2.0' ? "SQL" : "Widget Create"
+      traces[2].key?('Backtrace').must_equal false
+
       traces[3]['Layer'].must_equal "activerecord"
-      traces[3]['Label'].must_equal "entry"
-      traces[3]['Flavor'].must_equal "postgresql"
-      traces[3]['Query'].must_equal "INSERT INTO \"widgets\" (\"name\", \"description\", \"created_at\", \"updated_at\") VALUES ($?, $?, $?, $?) RETURNING \"id\""
-      traces[3]['Name'].must_equal Rails.version < '5.2.0' ? "SQL" : "Widget Create"
-      traces[3].key?('Backtrace').must_equal false
+      traces[3]['Label'].must_equal "exit"
 
       traces[4]['Layer'].must_equal "activerecord"
-      traces[4]['Label'].must_equal "exit"
+      traces[4]['Label'].must_equal "entry"
+      traces[4]['Flavor'].must_equal "postgresql"
+      traces[4]['Query'].must_equal "SELECT  \"widgets\".* FROM \"widgets\" WHERE \"widgets\".\"name\" = $? ORDER BY \"widgets\".\"id\" ASC LIMIT $?"
+      traces[4]['Name'].must_equal "Widget Load"
+      traces[4].key?('Backtrace').must_equal false
+      traces[4].key?('QueryArgs').must_equal false
 
       traces[5]['Layer'].must_equal "activerecord"
-      traces[5]['Label'].must_equal "entry"
-      traces[5]['Flavor'].must_equal "postgresql"
-      traces[5]['Query'].must_equal "SELECT  \"widgets\".* FROM \"widgets\" WHERE \"widgets\".\"name\" = $? ORDER BY \"widgets\".\"id\" ASC LIMIT $?"
-      traces[5]['Name'].must_equal "Widget Load"
-      traces[5].key?('Backtrace').must_equal false
-      traces[5].key?('QueryArgs').must_equal false
+      traces[5]['Label'].must_equal "exit"
 
       traces[6]['Layer'].must_equal "activerecord"
-      traces[6]['Label'].must_equal "exit"
+      traces[6]['Label'].must_equal "entry"
+      traces[6]['Flavor'].must_equal "postgresql"
+      traces[6]['Query'].must_equal "DELETE FROM \"widgets\" WHERE \"widgets\".\"id\" = $?"
+      traces[6]['Name'].must_equal Rails.version < '5.2.0' ? "SQL" : "Widget Destroy"
+      traces[6].key?('Backtrace').must_equal false
+      traces[6].key?('QueryArgs').must_equal false
 
       traces[7]['Layer'].must_equal "activerecord"
-      traces[7]['Label'].must_equal "entry"
-      traces[7]['Flavor'].must_equal "postgresql"
-      traces[7]['Query'].must_equal "DELETE FROM \"widgets\" WHERE \"widgets\".\"id\" = $?"
-      traces[7]['Name'].must_equal Rails.version < '5.2.0' ? "SQL" : "Widget Destroy"
-      traces[7].key?('Backtrace').must_equal false
-      traces[7].key?('QueryArgs').must_equal false
-
-      traces[8]['Layer'].must_equal "activerecord"
-      traces[8]['Label'].must_equal "exit"
+      traces[7]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[12]['X-Trace']
+      r.header['X-Trace'].must_equal traces[11]['X-Trace']
     end
 
     # Different behavior in Rails >= 5.2.0
@@ -144,7 +141,7 @@ if defined?(::Rails)
       r = Net::HTTP.get_response(uri)
 
       traces = get_all_traces
-      traces.count.must_equal 13
+      traces.count.must_equal 12
       valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
@@ -169,17 +166,9 @@ if defined?(::Rails)
       entry_traces[3].key?('Backtrace').must_equal false
       entry_traces[3].key?('QueryArgs').must_equal Rails.version < '5.2.0' ? true : false
 
-      entry_traces[4]['Layer'].must_equal "activerecord"
-      entry_traces[4]['Flavor'].must_equal "mysql"
-      entry_traces[4]['Query'].gsub!(/\d+/, 'ID')
-      entry_traces[4]['Query'].must_equal "DELETE FROM `widgets` WHERE `widgets`.`id` = ID"
-      entry_traces[4]['Name'].must_equal Rails.version < '5.2.0' ? "SQL" : "Widget Destroy"
-      entry_traces[4].key?('Backtrace').must_equal false
-      entry_traces[4].key?('QueryArgs').must_equal Rails.version < '5.2.0' ? true : false
-
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[12]['X-Trace']
+      r.header['X-Trace'].must_equal traces[11]['X-Trace']
     end
 
     # Different behavior in Rails >= 5.2.0
@@ -195,7 +184,7 @@ if defined?(::Rails)
       r = Net::HTTP.get_response(uri)
 
       traces = get_all_traces
-      traces.count.must_equal 13
+      traces.count.must_equal 12
       valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
@@ -228,7 +217,7 @@ if defined?(::Rails)
 
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[12]['X-Trace']
+      r.header['X-Trace'].must_equal traces[11]['X-Trace']
     end
 
 
@@ -240,7 +229,7 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 5
+      traces.count.must_equal 4
       unless defined?(JRUBY_VERSION)
         # We don't test this under JRuby because the Java instrumentation
         # for the DB drivers doesn't use our test reporter hence we won't
@@ -253,27 +242,24 @@ if defined?(::Rails)
       traces[0]['Label'].must_equal "entry"
       traces[0]['URL'].must_equal "/hello/metal"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Label'].must_equal "profile_entry"
+      traces[1]['Language'].must_equal "ruby"
+      traces[1]['ProfileName'].must_equal "world"
+      traces[1]['MethodName'].must_equal "world"
+      traces[1]['Class'].must_equal "FerroController"
+      traces[1]['Controller'].must_equal "FerroController"
+      traces[1]['Action'].must_equal "world"
 
-      traces[2]['Label'].must_equal "profile_entry"
+      traces[2]['Label'].must_equal "profile_exit"
       traces[2]['Language'].must_equal "ruby"
       traces[2]['ProfileName'].must_equal "world"
-      traces[2]['MethodName'].must_equal "world"
-      traces[2]['Class'].must_equal "FerroController"
-      traces[2]['Controller'].must_equal "FerroController"
-      traces[2]['Action'].must_equal "world"
 
-      traces[3]['Label'].must_equal "profile_exit"
-      traces[3]['Language'].must_equal "ruby"
-      traces[3]['ProfileName'].must_equal "world"
-
-      traces[4]['Layer'].must_equal "rack"
-      traces[4]['Label'].must_equal "exit"
+      traces[3]['Layer'].must_equal "rack"
+      traces[3]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[4]['X-Trace']
+      r.header['X-Trace'].must_equal traces[3]['X-Trace']
     end
 
     it "should collect backtraces when true" do
@@ -284,7 +270,7 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 7
+      traces.count.must_equal 6
       unless defined?(JRUBY_VERSION)
         # We don't test this under JRuby because the Java instrumentation
         # for the DB drivers doesn't use our test reporter hence we won't
@@ -297,30 +283,27 @@ if defined?(::Rails)
       traces[0]['Label'].must_equal "entry"
       traces[0]['URL'].must_equal "/hello/world"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Layer'].must_equal "rails"
+      traces[1]['Label'].must_equal "entry"
+      traces[1]['Controller'].must_equal "HelloController"
+      traces[1]['Action'].must_equal "world"
+      traces[1].key?('Backtrace').must_equal true
 
-      traces[2]['Layer'].must_equal "rails"
+      traces[2]['Layer'].must_equal "actionview"
       traces[2]['Label'].must_equal "entry"
-      traces[2]['Controller'].must_equal "HelloController"
-      traces[2]['Action'].must_equal "world"
-      traces[2].key?('Backtrace').must_equal true
 
       traces[3]['Layer'].must_equal "actionview"
-      traces[3]['Label'].must_equal "entry"
+      traces[3]['Label'].must_equal "exit"
 
-      traces[4]['Layer'].must_equal "actionview"
+      traces[4]['Layer'].must_equal "rails"
       traces[4]['Label'].must_equal "exit"
 
-      traces[5]['Layer'].must_equal "rails"
+      traces[5]['Layer'].must_equal "rack"
       traces[5]['Label'].must_equal "exit"
-
-      traces[6]['Layer'].must_equal "rack"
-      traces[6]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[6]['X-Trace']
+      r.header['X-Trace'].must_equal traces[5]['X-Trace']
     end
 
     it "should NOT collect backtraces when false" do
@@ -331,7 +314,7 @@ if defined?(::Rails)
 
       traces = get_all_traces
 
-      traces.count.must_equal 7
+      traces.count.must_equal 6
       unless defined?(JRUBY_VERSION)
         # We don't test this under JRuby because the Java instrumentation
         # for the DB drivers doesn't use our test reporter hence we won't
@@ -344,30 +327,27 @@ if defined?(::Rails)
       traces[0]['Label'].must_equal "entry"
       traces[0]['URL'].must_equal "/hello/world"
 
-      traces[1]['Layer'].must_equal "rack"
-      traces[1]['Label'].must_equal "info"
+      traces[1]['Layer'].must_equal "rails"
+      traces[1]['Label'].must_equal "entry"
+      traces[1]['Controller'].must_equal "HelloController"
+      traces[1]['Action'].must_equal "world"
+      traces[1].key?('Backtrace').must_equal false
 
-      traces[2]['Layer'].must_equal "rails"
+      traces[2]['Layer'].must_equal "actionview"
       traces[2]['Label'].must_equal "entry"
-      traces[2]['Controller'].must_equal "HelloController"
-      traces[2]['Action'].must_equal "world"
-      traces[2].key?('Backtrace').must_equal false
 
       traces[3]['Layer'].must_equal "actionview"
-      traces[3]['Label'].must_equal "entry"
+      traces[3]['Label'].must_equal "exit"
 
-      traces[4]['Layer'].must_equal "actionview"
+      traces[4]['Layer'].must_equal "rails"
       traces[4]['Label'].must_equal "exit"
 
-      traces[5]['Layer'].must_equal "rails"
+      traces[5]['Layer'].must_equal "rack"
       traces[5]['Label'].must_equal "exit"
-
-      traces[6]['Layer'].must_equal "rack"
-      traces[6]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
-      r.header['X-Trace'].must_equal traces[6]['X-Trace']
+      r.header['X-Trace'].must_equal traces[5]['X-Trace']
     end
 
     it 'should log one exception and create unbroken traces when there is an exception' do

--- a/test/frameworks/sinatra_test.rb
+++ b/test/frameworks/sinatra_test.rb
@@ -9,6 +9,11 @@ require File.expand_path(File.dirname(__FILE__) + '/apps/sinatra_simple')
 describe Sinatra do
   before do
     clear_all_traces
+    @bt = AppOpticsAPM::Config[:sinatra][:collect_backtraces]
+  end
+
+  after do
+    AppOpticsAPM::Config[:sinatra][:collect_backtraces] = @bt
   end
 
   it "should trace a request to a simple sinatra stack" do
@@ -27,12 +32,15 @@ describe Sinatra do
     traces[6]['Controller'].must_equal "SinatraSimple"
     traces[7]['Label'].must_equal "exit"
 
+    layer_has_key_once(traces, 'sinatra', 'Backtrace')
+
     # Validate the existence of the response header
     r.headers.key?('X-Trace').must_equal true
     r.headers['X-Trace'].must_equal traces[7]['X-Trace']
   end
 
   it "should log an error on exception" do
+    AppOpticsAPM::Config[:sinatra][:collect_backtraces] = false
     @app = SinatraSimple
 
     SinatraSimple.any_instance.expects(:dispatch_without_appoptics).raises(StandardError.new('Hello Sinatra'))
@@ -50,13 +58,25 @@ describe Sinatra do
 
     traces[1]['Layer'].must_equal "sinatra"
 
-    error_trace = traces.find{ |trace| trace['Label'] == 'error' }
+    error_traces = traces.select{ |trace| trace['Label'] == 'error' }
+    error_traces.size.must_equal 1
 
+    error_trace = error_traces[0]
     error_trace['Layer'].must_equal 'sinatra'
     error_trace['Spec'].must_equal 'error'
     error_trace['ErrorClass'].must_equal 'StandardError'
     error_trace['ErrorMsg'].must_equal 'Hello Sinatra'
-    traces.select { |trace| trace['Label'] == 'error' }.count.must_equal 1
+  end
+
+  it 'should not report backtraces' do
+    AppOpticsAPM::Config[:sinatra][:collect_backtraces] = false
+    @app = SinatraSimple
+
+    r = get "/render"
+
+    traces = get_all_traces
+
+    layer_doesnt_have_key(traces, 'sinatra', 'Backtrace')
   end
 
   it "should not have RUM code in the response" do

--- a/test/frameworks/sinatra_test.rb
+++ b/test/frameworks/sinatra_test.rb
@@ -18,18 +18,18 @@ describe Sinatra do
 
     traces = get_all_traces
 
-    traces.count.must_equal 9
+    traces.count.must_equal 8
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rack')
 
-    traces[2]['Layer'].must_equal "sinatra"
-    traces[4]['Label'].must_equal "profile_entry"
-    traces[7]['Controller'].must_equal "SinatraSimple"
-    traces[8]['Label'].must_equal "exit"
+    traces[1]['Layer'].must_equal "sinatra"
+    traces[3]['Label'].must_equal "profile_entry"
+    traces[6]['Controller'].must_equal "SinatraSimple"
+    traces[7]['Label'].must_equal "exit"
 
     # Validate the existence of the response header
     r.headers.key?('X-Trace').must_equal true
-    r.headers['X-Trace'].must_equal traces[8]['X-Trace']
+    r.headers['X-Trace'].must_equal traces[7]['X-Trace']
   end
 
   it "should log an error on exception" do
@@ -44,11 +44,11 @@ describe Sinatra do
 
     traces = get_all_traces
 
-    traces.count.must_equal 6
+    traces.count.must_equal 5
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rack')
 
-    traces[2]['Layer'].must_equal "sinatra"
+    traces[1]['Layer'].must_equal "sinatra"
 
     error_trace = traces.find{ |trace| trace['Label'] == 'error' }
 

--- a/test/instrumentation/bunny_consumer_test.rb
+++ b/test/instrumentation/bunny_consumer_test.rb
@@ -45,13 +45,13 @@ unless defined?(JRUBY_VERSION)
 
       traces = get_all_traces
 
-      traces.count.must_equal 11
+      traces.count.must_equal 10
       assert valid_edges?(traces, false), "Invalid edge in traces"
 
       traces[5]['Layer'].must_equal "net-http"
       traces[5]['Label'].must_equal "entry"
-      traces[9]['Layer'].must_equal "net-http"
-      traces[9]['Label'].must_equal "exit"
+      traces[8]['Layer'].must_equal "net-http"
+      traces[8]['Label'].must_equal "exit"
 
       traces[4]['Spec'].must_equal "job"
       traces[4]['Flavor'].must_equal "rabbitmq"
@@ -90,15 +90,15 @@ unless defined?(JRUBY_VERSION)
       sleep 1
 
       traces = get_all_traces
-      traces.count.must_equal 7
+      traces.count.must_equal 6
 
       validate_outer_layers(traces, "rabbitmq-consumer")
       assert valid_edges?(traces), "Invalid edge in traces"
 
       traces[1]['Layer'].must_equal "net-http"
       traces[1]['Label'].must_equal "entry"
-      traces[5]['Layer'].must_equal "net-http"
-      traces[5]['Label'].must_equal "exit"
+      traces[4]['Layer'].must_equal "net-http"
+      traces[4]['Label'].must_equal "exit"
 
       traces[0]['Spec'].must_equal "job"
       traces[0]['Flavor'].must_equal "rabbitmq"
@@ -182,7 +182,7 @@ unless defined?(JRUBY_VERSION)
 
       traces = get_all_traces
 
-      traces.count.must_equal 11
+      traces.count.must_equal 10
       assert valid_edges?(traces, false), "Invalid edge in traces"
 
       traces[4]['Spec'].must_equal "job"

--- a/test/instrumentation/curb_test.rb
+++ b/test/instrumentation/curb_test.rb
@@ -33,20 +33,20 @@ unless defined?(JRUBY_VERSION)
 
     def assert_correct_traces(url, method)
       traces = get_all_traces
-      assert_equal 7, traces.count, "Trace count"
+      assert_equal 6, traces.count, "Trace count"
       validate_outer_layers(traces, "curb_tests")
 
       assert_equal 'curb',                    traces[1]['Layer']
       assert_equal 'entry',                   traces[1]['Label']
-      assert_equal 'rsc',                         traces[1]['Spec']
+      assert_equal 'rsc',                     traces[1]['Spec']
       assert_equal 1,                         traces[1]['IsService']
       # curb started using URI#to_s and may have a trailing '?', https://github.com/taf2/curb/commit/32fa6d78968c3b63e2a54a2c326efb577db04043
       assert_equal url,                       traces[1]['RemoteURL'].chomp('?')
       assert_equal method,                    traces[1]['HTTPMethod']
-      assert                                  traces[1]['Backtrace']
 
-      assert_equal 'curb',                    traces[5]['Layer']
-      assert_equal 'exit',                    traces[5]['Label']
+      assert_equal 'curb',                    traces[4]['Layer']
+      assert_equal 'exit',                    traces[4]['Label']
+      assert                                  traces[4]['Backtrace']
     end
 
     def test_reports_version_init
@@ -172,7 +172,7 @@ unless defined?(JRUBY_VERSION)
       assert response.header_str =~ /X-Trace/, "X-Trace response header"
 
       traces = get_all_traces
-      assert_equal 7, traces.count, "Trace count"
+      assert_equal 6, traces.count, "Trace count"
       validate_outer_layers(traces, "curb_tests")
 
       assert_correct_traces('http://127.0.0.1:8101/', 'GET')
@@ -195,13 +195,13 @@ unless defined?(JRUBY_VERSION)
       end
 
       traces = get_all_traces
-      assert_equal 13, traces.count, "Trace count"
+      assert_equal 10, traces.count, "Trace count"
       validate_outer_layers(traces, "curb_tests")
 
       assert_equal traces[1]['Layer'], 'curb_multi'
       assert_equal traces[1]['Label'], 'entry'
-      assert_equal traces[11]['Layer'], 'curb_multi'
-      assert_equal traces[11]['Label'], 'exit'
+      assert_equal traces[8]['Layer'], 'curb_multi'
+      assert_equal traces[8]['Label'], 'exit'
     end
 
     def test_multi_basic_post
@@ -220,13 +220,13 @@ unless defined?(JRUBY_VERSION)
       end
 
       traces = get_all_traces
-      assert_equal 13, traces.count, "Trace count"
+      assert_equal 10, traces.count, "Trace count"
       validate_outer_layers(traces, "curb_tests")
 
       assert_equal traces[1]['Layer'], 'curb_multi'
       assert_equal traces[1]['Label'], 'entry'
-      assert_equal traces[11]['Layer'], 'curb_multi'
-      assert_equal traces[11]['Label'], 'exit'
+      assert_equal traces[8]['Layer'], 'curb_multi'
+      assert_equal traces[8]['Label'], 'exit'
     end
 
     def test_multi_basic_get_pipeline
@@ -245,13 +245,13 @@ unless defined?(JRUBY_VERSION)
       end
 
       traces = get_all_traces
-      assert_equal 13, traces.count, "Trace count"
+      assert_equal 10, traces.count, "Trace count"
       validate_outer_layers(traces, "curb_tests")
 
       assert_equal traces[1]['Layer'], 'curb_multi'
       assert_equal traces[1]['Label'], 'entry'
-      assert_equal traces[11]['Layer'], 'curb_multi'
-      assert_equal traces[11]['Label'], 'exit'
+      assert_equal traces[8]['Layer'], 'curb_multi'
+      assert_equal traces[8]['Label'], 'exit'
     end
 
     def test_multi_advanced_get
@@ -278,13 +278,13 @@ unless defined?(JRUBY_VERSION)
       end
 
       traces = get_all_traces
-      assert_equal 13, traces.count, "Trace count"
+      assert_equal 10, traces.count, "Trace count"
       validate_outer_layers(traces, "curb_tests")
 
       assert_equal traces[1]['Layer'], 'curb_multi'
       assert_equal traces[1]['Label'], 'entry'
-      assert_equal traces[11]['Layer'], 'curb_multi'
-      assert_equal traces[11]['Label'], 'exit'
+      assert_equal traces[8]['Layer'], 'curb_multi'
+      assert_equal traces[8]['Label'], 'exit'
     end
 
     def test_requests_with_errors
@@ -305,7 +305,6 @@ unless defined?(JRUBY_VERSION)
       # curb started using URI#to_s and may have a trailing '?', https://github.com/taf2/curb/commit/32fa6d78968c3b63e2a54a2c326efb577db04043
       assert_equal 'http://asfjalkfjlajfljkaljf/',   traces[1]['RemoteURL'].chomp('?')
       assert_equal 'GET',                            traces[1]['HTTPMethod']
-      assert                                         traces[1]['Backtrace']
 
       assert_equal 'curb',                           traces[2]['Layer']
       assert_equal 'error',                          traces[2]['Spec']
@@ -317,6 +316,7 @@ unless defined?(JRUBY_VERSION)
 
       assert_equal 'curb',                           traces[3]['Layer']
       assert_equal 'exit',                           traces[3]['Label']
+      assert                                         traces[3]['Backtrace']
     end
 
     def test_obey_log_args_when_false
@@ -331,7 +331,7 @@ unless defined?(JRUBY_VERSION)
       }
 
       traces = get_all_traces
-      assert_equal 7, traces.count, "Trace count"
+      assert_equal 6, traces.count, "Trace count"
       assert_equal "http://127.0.0.1:8101/",         traces[1]['RemoteURL']
     end
 
@@ -347,7 +347,7 @@ unless defined?(JRUBY_VERSION)
       }
 
       traces = get_all_traces
-      assert_equal 7, traces.count, "Trace count"
+      assert_equal 6, traces.count, "Trace count"
       assert_equal "http://127.0.0.1:8101/?blah=1", traces[1]['RemoteURL']
     end
 
@@ -380,7 +380,7 @@ unless defined?(JRUBY_VERSION)
       }
 
       traces = get_all_traces
-      layer_has_key(traces, 'curb', 'Backtrace')
+      assert traces.find { |tr| tr['Layer'] == 'curb' && tr['Label'] == 'exit' }['Backtrace']
     end
 
     def test_obey_collect_backtraces_when_false

--- a/test/instrumentation/dalli_test.rb
+++ b/test/instrumentation/dalli_test.rb
@@ -48,16 +48,15 @@ describe "Dalli" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 5
+    traces.count.must_equal 4
 
     validate_outer_layers(traces, 'dalli_test')
 
     traces[1]['KVOp'].must_equal "get"
     traces[1]['KVKey'].must_equal "some_key"
     traces[1]['RemoteHost'].must_equal "127.0.0.1:11211"
-    traces[2]['Label'].must_equal "info"
     traces[2].has_key?('KVHit').must_equal true
-    traces[3]['Label'].must_equal "exit"
+    traces[2]['Label'].must_equal "exit"
   end
 
   it 'should trace get_multi' do
@@ -66,16 +65,15 @@ describe "Dalli" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 5
+    traces.count.must_equal 4
 
     validate_outer_layers(traces, 'dalli_test')
 
     traces[1]['KVOp'].must_equal "get_multi"
-    traces[2]['Label'].must_equal "info"
     traces[2]['RemoteHost'].must_equal "127.0.0.1:11211"
     traces[2].has_key?('KVKeyCount').must_equal true
     traces[2].has_key?('KVHitCount').must_equal true
-    traces[3]['Label'].must_equal "exit"
+    traces[2]['Label'].must_equal "exit"
   end
 
   it "should trace increment" do

--- a/test/instrumentation/excon_test.rb
+++ b/test/instrumentation/excon_test.rb
@@ -37,7 +37,7 @@ class ExconTest < Minitest::Test
     end
 
     traces = get_all_traces
-    assert_equal traces.count, 7
+    assert_equal 6, traces.count
     validate_outer_layers(traces, "excon_tests")
     assert valid_edges?(traces), "Invalid edge in traces"
 
@@ -45,11 +45,11 @@ class ExconTest < Minitest::Test
     assert_equal 1,                        traces[1]['IsService']
     assert_equal 'http://127.0.0.1:8101/', traces[1]['RemoteURL']
     assert_equal 'GET',                    traces[1]['HTTPMethod']
-    assert traces[1].key?('Backtrace')
 
-    assert_equal 'excon',     traces[5]['Layer']
-    assert_equal 'exit',      traces[5]['Label']
-    assert_equal 200,         traces[5]['HTTPStatus']
+    assert_equal 'excon',     traces[4]['Layer']
+    assert_equal 'exit',      traces[4]['Label']
+    assert_equal 200,         traces[4]['HTTPStatus']
+    assert traces[4].key?('Backtrace')
   end
 
   def test_cross_app_tracing
@@ -64,7 +64,7 @@ class ExconTest < Minitest::Test
     end
 
     traces = get_all_traces
-    assert_equal 7, traces.count
+    assert_equal 6, traces.count
     validate_outer_layers(traces, "excon_tests")
     assert valid_edges?(traces), "Invalid edge in traces"
 
@@ -72,8 +72,8 @@ class ExconTest < Minitest::Test
     assert_equal 1,                               traces[1]['IsService']
     assert_equal 'http://127.0.0.1:8101/?blah=1', traces[1]['RemoteURL']
     assert_equal 'GET',        traces[1]['HTTPMethod']
-    assert_equal 200,          traces[5]['HTTPStatus']
-    assert traces[1].key?('Backtrace')
+    assert_equal 200,          traces[4]['HTTPStatus']
+    assert traces[4].key?('Backtrace')
   end
 
   def test_cross_uninstr_app_tracing
@@ -92,10 +92,10 @@ class ExconTest < Minitest::Test
     assert_equal 'rsc',                           traces[1]['Spec']
     assert_equal 1,                               traces[1]['IsService']
     assert_equal 'http://127.0.0.1:8110/?blah=1', traces[1]['RemoteURL']
-    assert_equal 'GET',        traces[1]['HTTPMethod']
-    assert traces[1].key?('Backtrace')
+    assert_equal 'GET',                           traces[1]['HTTPMethod']
 
     assert_equal 200,          traces[2]['HTTPStatus']
+    assert traces[2].key?('Backtrace')
   end
 
 
@@ -113,32 +113,33 @@ class ExconTest < Minitest::Test
     end
 
     traces = get_all_traces
-    assert_equal traces.count, 17
+    assert_equal 14, traces.count
     validate_outer_layers(traces, "excon_tests")
     assert valid_edges?(traces), "Invalid edge in traces"
 
     assert_equal 'rsc',                    traces[1]['Spec']
     assert_equal 1,                        traces[1]['IsService']
     assert_equal 'http://127.0.0.1:8101/', traces[1]['RemoteURL']
-    assert_equal 'GET',         traces[1]['HTTPMethod']
-    assert_equal 200,           traces[5]['HTTPStatus']
-    assert traces[1].key?('Backtrace')
+    assert_equal 'GET',                    traces[1]['HTTPMethod']
 
-    assert_equal 'rsc',                    traces[6]['Spec']
-    assert_equal 1,                        traces[6]['IsService']
-    assert_equal 'http://127.0.0.1:8101/', traces[6]['RemoteURL']
-    assert_equal 'GET',         traces[6]['HTTPMethod']
+    assert_equal 200,                      traces[4]['HTTPStatus']
+    assert traces[4].key?('Backtrace')
 
-    assert_equal 200,           traces[10]['HTTPStatus']
-    assert traces[6].key?('Backtrace')
+    assert_equal 'rsc',                    traces[5]['Spec']
+    assert_equal 1,                        traces[5]['IsService']
+    assert_equal 'http://127.0.0.1:8101/', traces[5]['RemoteURL']
+    assert_equal 'GET',                    traces[5]['HTTPMethod']
 
-    assert_equal 'rsc',                    traces[11]['Spec']
-    assert_equal 1,                        traces[11]['IsService']
-    assert_equal 'http://127.0.0.1:8101/', traces[11]['RemoteURL']
+    assert_equal 200,                      traces[8]['HTTPStatus']
 
-    assert_equal 'GET',         traces[11]['HTTPMethod']
-    assert_equal 200,           traces[15]['HTTPStatus']
-    assert traces[11].key?('Backtrace')
+    assert_equal 'rsc',                    traces[9]['Spec']
+    assert_equal 1,                        traces[9]['IsService']
+    assert_equal 'http://127.0.0.1:8101/', traces[9]['RemoteURL']
+
+    assert_equal 'GET',                    traces[9]['HTTPMethod']
+
+    assert_equal 200,                      traces[12]['HTTPStatus']
+    assert traces[12].key?('Backtrace')
   end
 
   def test_pipelined_requests
@@ -150,7 +151,7 @@ class ExconTest < Minitest::Test
     end
 
     traces = get_all_traces
-    assert_equal 10, traces.count
+    assert_equal 8, traces.count
     validate_outer_layers(traces, "excon_tests")
     assert valid_edges?(traces, false), "Invalid edge in traces"
 
@@ -161,7 +162,7 @@ class ExconTest < Minitest::Test
     assert_equal 'GET,PUT',                traces[1]['HTTPMethods']
     assert traces[1].key?('Backtrace')
 
-    assert_equal '200,200',                traces[8]['HTTPStatuses']
+    assert_equal '200,200',                traces[6]['HTTPStatuses']
   end
 
   def test_requests_with_errors
@@ -175,14 +176,13 @@ class ExconTest < Minitest::Test
     end
 
     traces = get_all_traces
-    assert_equal traces.count, 5
+    assert_equal 5, traces.count
     validate_outer_layers(traces, "excon_tests")
     assert valid_edges?(traces), "Invalid edge in traces"
 
     assert_equal 'rsc',                       traces[1]['Spec']
     assert_equal 1,                           traces[1]['IsService']
     assert_equal 'http://asfjalkljkaljf:80/', traces[1]['RemoteURL']
-    assert traces[1].key?('Backtrace')
 
     assert_equal 'excon',                     traces[2]['Layer']
     assert_equal 'error',                     traces[2]['Spec']
@@ -194,6 +194,7 @@ class ExconTest < Minitest::Test
 
     assert_equal 'excon',                     traces[3]['Layer']
     assert_equal 'exit',                      traces[3]['Label']
+    assert traces[3].key?('Backtrace')
   end
 
   def test_obey_log_args_when_false
@@ -210,7 +211,7 @@ class ExconTest < Minitest::Test
     validate_outer_layers(traces, "excon_tests")
     assert valid_edges?(traces), "Invalid edge in traces"
 
-    assert_equal 7, traces.count
+    assert_equal 6, traces.count
     assert_equal 'http://127.0.0.1:8101/', traces[1]['RemoteURL']
 
     AppOpticsAPM::Config[:excon][:log_args] = @log_args
@@ -230,7 +231,7 @@ class ExconTest < Minitest::Test
     validate_outer_layers(traces, "excon_tests")
     assert valid_edges?(traces), "Invalid edge in traces"
 
-    assert_equal 7, traces.count
+    assert_equal 6, traces.count
     assert_equal 'http://127.0.0.1:8101/?blah=1', traces[1]['RemoteURL']
 
     AppOpticsAPM::Config[:excon][:log_args] = @log_args
@@ -250,7 +251,7 @@ class ExconTest < Minitest::Test
     validate_outer_layers(traces, "excon_tests")
     assert valid_edges?(traces), "Invalid edge in traces"
 
-    assert_equal 7, traces.count
+    assert_equal 6, traces.count
     assert_equal 'http://127.0.0.1:8101/?blah=1', traces[1]['RemoteURL']
 
     AppOpticsAPM::Config[:excon][:log_args] = @log_args

--- a/test/instrumentation/excon_test.rb
+++ b/test/instrumentation/excon_test.rb
@@ -160,7 +160,7 @@ class ExconTest < Minitest::Test
     assert_equal 'http://127.0.0.1:8101/', traces[1]['RemoteURL']
     assert_equal 'true',                   traces[1]['Pipeline']
     assert_equal 'GET,PUT',                traces[1]['HTTPMethods']
-    assert traces[1].key?('Backtrace')
+    assert traces[6].key?('Backtrace')
 
     assert_equal '200,200',                traces[6]['HTTPStatuses']
   end

--- a/test/instrumentation/faraday_test.rb
+++ b/test/instrumentation/faraday_test.rb
@@ -35,7 +35,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 9
+    traces.count.must_equal 8
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -43,16 +43,16 @@ describe "Faraday" do
     traces[1]['Layer'].must_equal 'faraday'
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:faraday][:collect_backtraces]
 
-    traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['Spec'].must_equal 'rsc'
-    traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/games?q=1'
-    traces[6]['HTTPMethod'].must_equal 'GET'
-    traces[6]['HTTPStatus'].must_equal '200'
+    traces[5]['Layer'].must_equal 'net-http'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Spec'].must_equal 'rsc'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/games?q=1'
+    traces[5]['HTTPMethod'].must_equal 'GET'
+    traces[5]['HTTPStatus'].must_equal '200'
 
-    traces[7]['Layer'].must_equal 'faraday'
-    traces[7]['Label'].must_equal 'exit'
+    traces[6]['Layer'].must_equal 'faraday'
+    traces[6]['Label'].must_equal 'exit'
   end
 
   it "should trace UNINSTRUMENTED cross-app request" do
@@ -94,7 +94,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 9
+    traces.count.must_equal 8
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -102,16 +102,16 @@ describe "Faraday" do
     traces[1]['Layer'].must_equal 'faraday'
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:faraday][:collect_backtraces]
 
-    traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['Spec'].must_equal 'rsc'
-    traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=ruby_test_suite'
-    traces[6]['HTTPMethod'].must_equal 'GET'
-    traces[6]['HTTPStatus'].must_equal '200'
+    traces[5]['Layer'].must_equal 'net-http'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Spec'].must_equal 'rsc'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=ruby_test_suite'
+    traces[5]['HTTPMethod'].must_equal 'GET'
+    traces[5]['HTTPStatus'].must_equal '200'
 
-    traces[7]['Layer'].must_equal 'faraday'
-    traces[7]['Label'].must_equal 'exit'
+    traces[6]['Layer'].must_equal 'faraday'
+    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace a Faraday class style request' do
@@ -120,7 +120,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 9
+    traces.count.must_equal 8
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -128,16 +128,16 @@ describe "Faraday" do
     traces[1]['Layer'].must_equal 'faraday'
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:faraday][:collect_backtraces]
 
-    traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['Spec'].must_equal 'rsc'
-    traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?a=1'
-    traces[6]['HTTPMethod'].must_equal 'GET'
-    traces[6]['HTTPStatus'].must_equal '200'
+    traces[5]['Layer'].must_equal 'net-http'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Spec'].must_equal 'rsc'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?a=1'
+    traces[5]['HTTPMethod'].must_equal 'GET'
+    traces[5]['HTTPStatus'].must_equal '200'
 
-    traces[7]['Layer'].must_equal 'faraday'
-    traces[7]['Label'].must_equal 'exit'
+    traces[6]['Layer'].must_equal 'faraday'
+    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace a Faraday with the excon adapter' do
@@ -149,7 +149,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 9
+    traces.count.must_equal 8
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -167,13 +167,13 @@ describe "Faraday" do
     traces[2]['RemoteProtocol'].must_be_nil
     traces[2]['RemoteHost'].must_be_nil
     traces[2]['ServiceArg'].must_be_nil
-    traces[6]['Layer'].must_equal 'excon'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['HTTPStatus'].must_equal 200
+    traces[5]['Layer'].must_equal 'excon'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['HTTPStatus'].must_equal 200
 
-    traces[7]['Layer'].must_equal 'faraday'
-    traces[7]['Label'].must_equal 'exit'
-    traces[7]['Middleware'].must_equal '[Faraday::Adapter::Excon]'
+    traces[6]['Layer'].must_equal 'faraday'
+    traces[6]['Label'].must_equal 'exit'
+    traces[6]['Middleware'].must_equal '[Faraday::Adapter::Excon]'
   end
 
   it 'should trace a Faraday with the httpclient adapter' do
@@ -185,7 +185,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 9
+    traces.count.must_equal 8
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -200,13 +200,13 @@ describe "Faraday" do
     traces[2]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
     traces[2]['HTTPMethod'].must_equal 'GET'
 
-    traces[6]['Layer'].must_equal 'httpclient'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['HTTPStatus'].must_equal 200
+    traces[5]['Layer'].must_equal 'httpclient'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['HTTPStatus'].must_equal 200
 
-    traces[7]['Layer'].must_equal 'faraday'
-    traces[7]['Label'].must_equal 'exit'
-    traces[7]['Middleware'].must_equal '[Faraday::Adapter::HTTPClient]'
+    traces[6]['Layer'].must_equal 'faraday'
+    traces[6]['Label'].must_equal 'exit'
+    traces[6]['Middleware'].must_equal '[Faraday::Adapter::HTTPClient]'
   end
 
   it 'should trace a Faraday with the typhoeus adapter' do
@@ -218,7 +218,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 9
+    traces.count.must_equal 8
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -229,17 +229,17 @@ describe "Faraday" do
     traces[2]['Layer'].must_equal 'typhoeus'
     traces[2]['Label'].must_equal 'entry'
 
-    traces[6]['Layer'].must_equal 'typhoeus'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['Spec'].must_equal 'rsc'
-    traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
-    traces[6]['HTTPMethod'].must_equal 'GET'
-    traces[6]['HTTPStatus'].must_equal 200
+    traces[5]['Layer'].must_equal 'typhoeus'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Spec'].must_equal 'rsc'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
+    traces[5]['HTTPMethod'].must_equal 'GET'
+    traces[5]['HTTPStatus'].must_equal 200
 
-    traces[7]['Layer'].must_equal 'faraday'
-    traces[7]['Label'].must_equal 'exit'
-    traces[7]['Middleware'].must_equal '[Faraday::Adapter::Typhoeus]'
+    traces[6]['Layer'].must_equal 'faraday'
+    traces[6]['Label'].must_equal 'exit'
+    traces[6]['Middleware'].must_equal '[Faraday::Adapter::Typhoeus]'
   end
 
   it 'should trace a Faraday with the UNINSTRUMENTED patron adapter' do
@@ -252,7 +252,7 @@ describe "Faraday" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
 
     assert valid_edges?(traces), "Invalid edge in traces"
     validate_outer_layers(traces, 'faraday_test')
@@ -263,18 +263,18 @@ describe "Faraday" do
     traces[2]['Layer'].must_equal 'rack'
     traces[2]['Label'].must_equal 'entry'
 
-    traces[4]['Layer'].must_equal 'rack'
-    traces[4]['Label'].must_equal 'exit'
-    traces[4]['Status'].must_equal 200
+    traces[3]['Layer'].must_equal 'rack'
+    traces[3]['Label'].must_equal 'exit'
+    traces[3]['Status'].must_equal 200
 
-    traces[5]['Spec'].must_equal 'rsc'
-    traces[5]['IsService'].must_equal 1
-    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
-    traces[5]['HTTPMethod'].must_equal 'GET'
-    traces[5]['HTTPStatus'].must_equal 200
-    traces[5]['Layer'].must_equal 'faraday'
-    traces[5]['Label'].must_equal 'exit'
-    traces[5]['Middleware'].must_equal '[Faraday::Adapter::Patron]'
+    traces[4]['Spec'].must_equal 'rsc'
+    traces[4]['IsService'].must_equal 1
+    traces[4]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
+    traces[4]['HTTPMethod'].must_equal 'GET'
+    traces[4]['HTTPStatus'].must_equal 200
+    traces[4]['Layer'].must_equal 'faraday'
+    traces[4]['Label'].must_equal 'exit'
+    traces[4]['Middleware'].must_equal '[Faraday::Adapter::Patron]'
   end
 
   it 'should trace a Faraday with the UNINSTRUMENTED patron adapter to UNINSTRUMENTED rack' do

--- a/test/instrumentation/grpc_test.rb
+++ b/test/instrumentation/grpc_test.rb
@@ -126,8 +126,8 @@ describe 'GRPC' do
       traces = get_all_traces.delete_if { |tr| tr['Layer'] == 'test'}
       traces.size.must_equal 2
 
-      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'entry' }.each { |tr| tr['Backtrace'].wont_be_nil "Backtrace missing" }
-      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'exit' }.each { |tr| tr['Backtrace'].must_be_nil "Extra backtrace in trace"}
+      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'entry' }.each { |tr| tr['Backtrace'].must_be_nil "Backtrace missing" }
+      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'exit' }.each { |tr| tr['Backtrace'].wont_be_nil "Extra backtrace in trace"}
 
       # stop_server
       # AppOpticsAPM::Config[:grpc_server][:collect_backtraces] = server_bt
@@ -321,7 +321,7 @@ describe 'GRPC' do
       traces[0]['RemoteURL'].must_equal       'grpc://localhost:50051/grpctest.TestService/client_stream'
       traces.each { |tr| tr['GRPCMethodType'].must_equal  'CLIENT_STREAMING' }
       traces.select { |tr| tr['Label'] == 'exit'}.each { |tr| tr['GRPCStatus'].must_equal 'OK' }
-      traces.select { |tr| tr['Label'] == 'entry'}.each { |tr| tr['Backtrace'].wont_be_nil "backtrace missing!" }
+      traces.select { |tr| tr['Label'] == 'exit'}.each { |tr| tr['Backtrace'].wont_be_nil "backtrace missing!" }
 
       # stop_server
       # AppOpticsAPM::Config[:grpc_server][:collect_backtraces] = server_bt
@@ -468,8 +468,8 @@ describe 'GRPC' do
       traces = get_all_traces.delete_if { |tr| tr['Layer'] == 'test'}
       traces.size.must_equal 2
 
-      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'entry' }.each { |tr| tr['Backtrace'].wont_be_nil "Backtrace missing" }
-      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'exit' }.each { |tr| tr['Backtrace'].must_be_nil "Extra backtrace in trace"}
+      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'entry' }.each { |tr| tr['Backtrace'].must_be_nil "Backtrace missing" }
+      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'exit' }.each { |tr| tr['Backtrace'].wont_be_nil "Extra backtrace in trace"}
 
       # stop_server
       # AppOpticsAPM::Config[:grpc_server][:collect_backtraces] = server_bt
@@ -619,8 +619,8 @@ describe 'GRPC' do
       traces = get_all_traces.delete_if { |tr| tr['Layer'] == 'test'}
       traces.size.must_equal 2
 
-      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'entry' }.each { |tr| tr['Backtrace'].wont_be_nil "Backtrace missing" }
-      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'exit' }.each { |tr| tr['Backtrace'].must_be_nil "Extra backtrace in trace"}
+      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'entry' }.each { |tr| tr['Backtrace'].must_be_nil "Backtrace missing" }
+      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'exit' }.each { |tr| tr['Backtrace'].wont_be_nil "Extra backtrace in trace"}
 
       # stop_server
       # AppOpticsAPM::Config[:grpc_server][:collect_backtraces] = server_bt
@@ -769,8 +769,8 @@ describe 'GRPC' do
       traces = get_all_traces.delete_if { |tr| tr['Layer'] == 'test'}
       traces.size.must_equal 2
 
-      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'entry' }.each { |tr| tr['Backtrace'].wont_be_nil "Backtrace missing" }
-      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'exit' }.each { |tr| tr['Backtrace'].must_be_nil "Extra backtrace in trace"}
+      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'entry' }.each { |tr| tr['Backtrace'].must_be_nil "Backtrace missing" }
+      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'exit' }.each { |tr| tr['Backtrace'].wont_be_nil "Extra backtrace in trace"}
 
       # stop_server
       # AppOpticsAPM::Config[:grpc_server][:collect_backtraces] = server_bt
@@ -919,8 +919,8 @@ describe 'GRPC' do
       traces = get_all_traces.delete_if { |tr| tr['Layer'] == 'test'}
       traces.size.must_equal 2
 
-      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'entry' }.each { |tr| tr['Backtrace'].wont_be_nil "Backtrace missing" }
-      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'exit' }.each { |tr| tr['Backtrace'].must_be_nil "Extra backtrace in trace"}
+      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'entry' }.each { |tr| tr['Backtrace'].must_be_nil "Backtrace missing" }
+      traces.select { |tr| tr['Layer'] =~ /grpc/ && tr['Label'] == 'exit' }.each { |tr| tr['Backtrace'].wont_be_nil "Extra backtrace in trace"}
 
       # stop_server
       # AppOpticsAPM::Config[:grpc_server][:collect_backtraces] = server_bt

--- a/test/instrumentation/http_test.rb
+++ b/test/instrumentation/http_test.rb
@@ -37,7 +37,7 @@ describe "Net::HTTP"  do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'net-http_test')
 
@@ -48,17 +48,14 @@ describe "Net::HTTP"  do
     traces[2]['Label'].must_equal 'entry'
 
     traces[3]['Layer'].must_equal 'rack'
-    traces[3]['Label'].must_equal 'info'
+    traces[3]['Label'].must_equal 'exit'
 
-    traces[4]['Layer'].must_equal 'rack'
-    traces[4]['Label'].must_equal 'exit'
-
-    traces[5]['Spec'].must_equal 'rsc'
-    traces[5]['IsService'].must_equal 1
-    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
-    traces[5]['HTTPMethod'].must_equal "GET"
-    traces[5]['HTTPStatus'].must_equal "200"
-    traces[5].has_key?('Backtrace').must_equal AppOpticsAPM::Config[:nethttp][:collect_backtraces]
+    traces[4]['Spec'].must_equal 'rsc'
+    traces[4]['IsService'].must_equal 1
+    traces[4]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
+    traces[4]['HTTPMethod'].must_equal "GET"
+    traces[4]['HTTPStatus'].must_equal "200"
+    traces[4].has_key?('Backtrace').must_equal AppOpticsAPM::Config[:nethttp][:collect_backtraces]
   end
 
   it "should trace a GET request" do
@@ -69,17 +66,17 @@ describe "Net::HTTP"  do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'net-http_test')
 
     traces[1]['Layer'].must_equal 'net-http'
-    traces[5]['Spec'].must_equal 'rsc'
-    traces[5]['IsService'].must_equal 1
-    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
-    traces[5]['HTTPMethod'].must_equal "GET"
-    traces[5]['HTTPStatus'].must_equal "200"
-    traces[5].has_key?('Backtrace').must_equal AppOpticsAPM::Config[:nethttp][:collect_backtraces]
+    traces[4]['Spec'].must_equal 'rsc'
+    traces[4]['IsService'].must_equal 1
+    traces[4]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=1'
+    traces[4]['HTTPMethod'].must_equal "GET"
+    traces[4]['HTTPStatus'].must_equal "200"
+    traces[4].has_key?('Backtrace').must_equal AppOpticsAPM::Config[:nethttp][:collect_backtraces]
   end
 
   it "should trace a GET request to an uninstrumented app" do
@@ -114,7 +111,7 @@ describe "Net::HTTP"  do
     end
 
     traces = get_all_traces
-    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=ruby_test_suite'
+    traces[4]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?q=ruby_test_suite'
   end
 
   it "should obey :log_args setting when false" do
@@ -128,7 +125,7 @@ describe "Net::HTTP"  do
     end
 
     traces = get_all_traces
-    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
+    traces[4]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
   end
 
   it "should obey :collect_backtraces setting when true" do

--- a/test/instrumentation/httpclient_test.rb
+++ b/test/instrumentation/httpclient_test.rb
@@ -39,7 +39,7 @@ unless defined?(JRUBY_VERSION)
       end
 
       traces = get_all_traces
-      assert_equal 7, traces.count
+      assert_equal 6, traces.count
       assert valid_edges?(traces), "Invalid edge in traces"
       validate_outer_layers(traces, "httpclient_tests")
 
@@ -47,11 +47,11 @@ unless defined?(JRUBY_VERSION)
       assert_equal traces[1]['IsService'], 1
       assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/?keyword=ruby&lang=en'
       assert_equal traces[1]['HTTPMethod'], 'GET'
-      assert traces[1].key?('Backtrace')
 
-      assert_equal traces[5]['Layer'], 'httpclient'
-      assert_equal traces[5]['Label'], 'exit'
-      assert_equal traces[5]['HTTPStatus'], 200
+      assert_equal traces[4]['Layer'], 'httpclient'
+      assert_equal traces[4]['Label'], 'exit'
+      assert_equal traces[4]['HTTPStatus'], 200
+      assert traces[4].key?('Backtrace')
     end
 
     def test_get_request_to_uninstr_app
@@ -70,11 +70,11 @@ unless defined?(JRUBY_VERSION)
       assert_equal traces[1]['IsService'], 1
       assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8110/?keyword=ruby&lang=en'
       assert_equal traces[1]['HTTPMethod'], 'GET'
-      assert traces[1].key?('Backtrace')
 
       assert_equal traces[2]['Layer'], 'httpclient'
       assert_equal traces[2]['Label'], 'exit'
       assert_equal traces[2]['HTTPStatus'], 200
+      assert traces[2].key?('Backtrace')
     end
 
     def test_get_with_header_hash
@@ -90,7 +90,7 @@ unless defined?(JRUBY_VERSION)
       assert xtrace
       assert AppOpticsAPM::XTrace.valid?(xtrace)
 
-      assert_equal 7, traces.count
+      assert_equal 6, traces.count
       assert valid_edges?(traces), "Invalid edge in traces"
       validate_outer_layers(traces, "httpclient_tests")
 
@@ -98,11 +98,11 @@ unless defined?(JRUBY_VERSION)
       assert_equal traces[1]['IsService'], 1
       assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/'
       assert_equal traces[1]['HTTPMethod'], 'GET'
-      assert traces[1].key?('Backtrace')
 
-      assert_equal traces[5]['Layer'], 'httpclient'
-      assert_equal traces[5]['Label'], 'exit'
-      assert_equal traces[5]['HTTPStatus'], 200
+      assert_equal traces[4]['Layer'], 'httpclient'
+      assert_equal traces[4]['Label'], 'exit'
+      assert_equal traces[4]['HTTPStatus'], 200
+      assert traces[4].key?('Backtrace')
     end
 
     def test_get_with_header_array
@@ -119,7 +119,7 @@ unless defined?(JRUBY_VERSION)
       assert xtrace
       assert AppOpticsAPM::XTrace.valid?(xtrace)
 
-      assert_equal 7, traces.count
+      assert_equal 6, traces.count
       assert valid_edges?(traces), "Invalid edge in traces"
       validate_outer_layers(traces, "httpclient_tests")
 
@@ -127,11 +127,11 @@ unless defined?(JRUBY_VERSION)
       assert_equal traces[1]['IsService'], 1
       assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/'
       assert_equal traces[1]['HTTPMethod'], 'GET'
-      assert traces[1].key?('Backtrace')
 
-      assert_equal traces[5]['Layer'], 'httpclient'
-      assert_equal traces[5]['Label'], 'exit'
-      assert_equal traces[5]['HTTPStatus'], 200
+      assert_equal traces[4]['Layer'], 'httpclient'
+      assert_equal traces[4]['Label'], 'exit'
+      assert_equal traces[4]['HTTPStatus'], 200
+      assert traces[4].key?('Backtrace')
     end
 
     def test_post_request
@@ -148,7 +148,7 @@ unless defined?(JRUBY_VERSION)
       assert xtrace
       assert AppOpticsAPM::XTrace.valid?(xtrace)
 
-      assert_equal 7, traces.count
+      assert_equal 6, traces.count
       assert valid_edges?(traces), "Invalid edge in traces"
       validate_outer_layers(traces, "httpclient_tests")
 
@@ -156,11 +156,11 @@ unless defined?(JRUBY_VERSION)
       assert_equal traces[1]['IsService'], 1
       assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/'
       assert_equal traces[1]['HTTPMethod'], 'POST'
-      assert traces[1].key?('Backtrace')
 
-      assert_equal traces[5]['Layer'], 'httpclient'
-      assert_equal traces[5]['Label'], 'exit'
-      assert_equal traces[5]['HTTPStatus'], 200
+      assert_equal traces[4]['Layer'], 'httpclient'
+      assert_equal traces[4]['Label'], 'exit'
+      assert_equal traces[4]['HTTPStatus'], 200
+      assert traces[4].key?('Backtrace')
     end
 
     def test_async_get
@@ -176,7 +176,7 @@ unless defined?(JRUBY_VERSION)
 
       traces = get_all_traces
 
-      assert_equal 7, traces.count
+      assert_equal 6, traces.count
       assert valid_edges?(traces, false), "Invalid edge in traces"
 
       # In the case of async the layers are not always ordered the same
@@ -190,11 +190,11 @@ unless defined?(JRUBY_VERSION)
       assert_equal 1, async_entry['IsService']
       assert_equal 'http://127.0.0.1:8101/?blah=1', async_entry['RemoteURL']
       assert_equal 'GET', async_entry['HTTPMethod']
-      assert async_entry.key?('Backtrace')
 
-      assert_equal 'httpclient', traces[6]['Layer']
-      assert_equal 'exit', traces[6]['Label']
-      assert_equal 200, traces[6]['HTTPStatus']
+      assert_equal 'httpclient', traces[5]['Layer']
+      assert_equal 'exit', traces[5]['Label']
+      assert_equal 200, traces[5]['HTTPStatus']
+      assert traces[5].key?('Backtrace')
     end
 
     def test_cross_app_tracing
@@ -211,7 +211,7 @@ unless defined?(JRUBY_VERSION)
 
       traces = get_all_traces
 
-      assert_equal 7, traces.count
+      assert_equal 6, traces.count
       assert valid_edges?(traces), "Invalid edge in traces"
       validate_outer_layers(traces, "httpclient_tests")
 
@@ -219,18 +219,16 @@ unless defined?(JRUBY_VERSION)
       assert_equal 1, traces[1]['IsService']
       assert_equal 'http://127.0.0.1:8101/?keyword=ruby&lang=en', traces[1]['RemoteURL']
       assert_equal 'GET', traces[1]['HTTPMethod']
-      assert traces[1].key?('Backtrace')
 
       assert_equal 'rack', traces[2]['Layer']
       assert_equal 'entry', traces[2]['Label']
       assert_equal 'rack', traces[3]['Layer']
-      assert_equal 'info', traces[3]['Label']
-      assert_equal 'rack', traces[4]['Layer']
-      assert_equal 'exit', traces[4]['Label']
+      assert_equal 'exit', traces[3]['Label']
 
-      assert_equal 'httpclient', traces[5]['Layer']
-      assert_equal 'exit', traces[5]['Label']
-      assert_equal 200, traces[5]['HTTPStatus']
+      assert_equal 'httpclient', traces[4]['Layer']
+      assert_equal 'exit', traces[4]['Label']
+      assert_equal 200, traces[4]['HTTPStatus']
+      assert traces[4].key?('Backtrace')
     end
 
     def test_requests_with_errors
@@ -238,7 +236,7 @@ unless defined?(JRUBY_VERSION)
       begin
         AppOpticsAPM::API.start_trace('httpclient_tests') do
           clnt = HTTPClient.new
-          result = clnt.get('http://asfjalkfjlajfljkaljf/')
+          clnt.get('http://asfjalkfjlajfljkaljf/')
         end
       rescue
       end
@@ -252,7 +250,6 @@ unless defined?(JRUBY_VERSION)
       assert_equal 1, traces[1]['IsService']
       assert_equal 'http://asfjalkfjlajfljkaljf/', traces[1]['RemoteURL']
       assert_equal 'GET', traces[1]['HTTPMethod']
-      assert traces[1].key?('Backtrace')
 
       assert_equal 'httpclient', traces[2]['Layer']
       assert_equal 'error', traces[2]['Spec']
@@ -266,6 +263,7 @@ unless defined?(JRUBY_VERSION)
 
       assert_equal 'httpclient', traces[3]['Layer']
       assert_equal 'exit', traces[3]['Label']
+      assert traces[3].key?('Backtrace')
     end
 
     def test_log_args_when_true
@@ -285,7 +283,7 @@ unless defined?(JRUBY_VERSION)
       assert xtrace
       assert AppOpticsAPM::XTrace.valid?(xtrace)
 
-      assert_equal 7, traces.count
+      assert_equal 6, traces.count
       assert valid_edges?(traces), "Invalid edge in traces"
 
       assert_equal 'http://127.0.0.1:8101/?keyword=ruby&lang=en', traces[1]['RemoteURL']
@@ -310,7 +308,7 @@ unless defined?(JRUBY_VERSION)
       assert xtrace
       assert AppOpticsAPM::XTrace.valid?(xtrace)
 
-      assert_equal 7, traces.count
+      assert_equal 6, traces.count
       assert valid_edges?(traces), "Invalid edge in traces"
 
       assert_equal 'http://127.0.0.1:8101/', traces[1]['RemoteURL']
@@ -324,7 +322,7 @@ unless defined?(JRUBY_VERSION)
 
       traces = get_all_traces
       # we only get traces from rack
-      assert_equal 3, traces.count
+      assert_equal 2, traces.count
       traces.each do |trace|
         assert_equal 'rack', trace["Layer"]
       end

--- a/test/instrumentation/memcached_test.rb
+++ b/test/instrumentation/memcached_test.rb
@@ -83,12 +83,11 @@ unless defined?(JRUBY_VERSION)
       end
 
       traces = get_all_traces
-      traces.count.must_equal 5
+      traces.count.must_equal 4
 
       validate_outer_layers(traces, 'memcached_test')
       validate_event_keys(traces[1], @entry_kvs)
-      validate_event_keys(traces[2], @info_kvs)
-      validate_event_keys(traces[3], @exit_kvs)
+      validate_event_keys(traces[2], @exit_kvs)
 
       traces[1]['KVOp'].must_equal "get_multi"
 
@@ -226,7 +225,7 @@ unless defined?(JRUBY_VERSION)
       end
 
       traces = get_all_traces
-      layer_has_key(traces, 'memcache', 'Backtrace')
+      traces.find { |tr| tr['Layer'] == 'memcache' && tr['Label'] == 'exit'}.has_key?('Backtrace')
     end
 
     it "should obey :collect_backtraces setting when false" do

--- a/test/instrumentation/mongo_v1_test.rb
+++ b/test/instrumentation/mongo_v1_test.rb
@@ -7,6 +7,8 @@ unless ENV['APPOPTICS_MONGO_SERVER']
   ENV['APPOPTICS_MONGO_SERVER'] = "127.0.0.1:27017"
 end
 
+
+# TODO remove these tests, they fail with old mongos and we can't really setup for newer mongo < '2.0.0'
 if Gem.loaded_specs['mongo'].version.to_s < '2.0.0'
   describe "Mongo" do
     before do

--- a/test/instrumentation/mongo_v2_index_test.rb
+++ b/test/instrumentation/mongo_v2_index_test.rb
@@ -3,9 +3,8 @@
 
 require 'minitest_helper'
 
-unless ENV['APPOPTICS_MONGO_SERVER']
-  ENV['APPOPTICS_MONGO_SERVER'] = "127.0.0.1:27017"
-end
+ENV['APPOPTICS_MONGO_SERVER'] ||= "127.0.0.1:27017"
+ENV['APPOPTICS_MONGO_SERVER'] += ':27017' unless ENV['APPOPTICS_MONGO_SERVER'] =~ /\:27017$/
 
 if defined?(::Mongo::VERSION) && Mongo::VERSION >= '2.0.0'
   describe "MongoIndex" do

--- a/test/instrumentation/mongo_v2_test.rb
+++ b/test/instrumentation/mongo_v2_test.rb
@@ -3,8 +3,8 @@
 
 require 'minitest_helper'
 
-ENV['APPOPTICS_MONGO_SERVER'] = "127.0.0.1:27017" unless ENV['APPOPTICS_MONGO_SERVER']
-ENV['APPOPTICS_MONGO_SERVER'] += ":27017" unless ENV['APPOPTICS_MONGO_SERVER'] =~ /\:27017$/
+ENV['APPOPTICS_MONGO_SERVER'] ||= "127.0.0.1:27017"
+ENV['APPOPTICS_MONGO_SERVER'] += ':27017' unless ENV['APPOPTICS_MONGO_SERVER'] =~ /\:27017$/
 
 if defined?(::Mongo::VERSION) && Mongo::VERSION >= '2.0.0'
   describe "MongoCollection" do

--- a/test/instrumentation/mongo_v2_view_test.rb
+++ b/test/instrumentation/mongo_v2_view_test.rb
@@ -4,7 +4,7 @@
 require 'minitest_helper'
 
 
-ENV['APPOPTICS_MONGO_SERVER'] = "127.0.0.1:27017" unless ENV['APPOPTICS_MONGO_SERVER']
+ENV['APPOPTICS_MONGO_SERVER'] ||= "127.0.0.1:27017"
 ENV['APPOPTICS_MONGO_SERVER'] += ':27017' unless ENV['APPOPTICS_MONGO_SERVER'] =~ /\:27017$/
 
 if defined?(::Mongo::VERSION) && Mongo::VERSION >= '2.0.0'

--- a/test/instrumentation/rack_traces_test.rb
+++ b/test/instrumentation/rack_traces_test.rb
@@ -30,44 +30,49 @@ class RackTestApp < Minitest::Test
     }
   end
 
+  def setup
+    @bt = AppOpticsAPM::Config[:rack][:collect_backtraces]
+    @log_args = AppOpticsAPM::Config[:rack][:log_args]
+    clear_all_traces
+  end
+
   def teardown
+    AppOpticsAPM::Config[:rack][:collect_backtraces] = @bt
+    AppOpticsAPM::Config[:rack][:log_args] =  @log_args
     AppOpticsAPM::Config[:tracing_mode] = :always
   end
 
   def test_get_the_lobster
     # skip("FIXME: broken on travis only") if ENV['TRAVIS'] == "true"
 
-    clear_all_traces
-
     get "/lobster"
 
     traces = get_all_traces
-    traces.count.must_equal 3
+    traces.count.must_equal 2
 
     validate_outer_layers(traces, 'rack')
 
     kvs = {}
     kvs["Label"] = "entry"
     kvs["URL"] = "/lobster"
-    validate_event_keys(traces[0], kvs)
-
-    kvs.clear
-    kvs["Layer"] = "rack"
-    kvs["Label"] = "info"
     kvs["HTTP-Host"] = "example.org"
     kvs["Port"] = 80
     kvs["Proto"] = "http"
     kvs["Method"] = "GET"
     kvs["ClientIP"] = "127.0.0.1"
-    validate_event_keys(traces[1], kvs)
-
+    validate_event_keys(traces[0], kvs)
     assert traces[0].has_key?('SampleRate')
     assert traces[0].has_key?('SampleSource')
-    assert traces[1].has_key?('ProcessID')
-    assert traces[1].has_key?('ThreadID')
+    assert traces[0].has_key?('ProcessID')
+    assert traces[0].has_key?('ThreadID')
+    assert traces[0]['Backtrace']
+    assert traces[0]['Backtrace'].size > 0
 
-    assert traces[2]["Label"] == 'exit'
-    assert traces[2]["Status"] == 200
+    kvs.clear
+    kvs["Layer"] = "rack"
+    kvs["Label"] = "exit"
+    kvs['Status'] = 200
+    validate_event_keys(traces[1], kvs)
 
     assert last_response.ok?
 
@@ -75,7 +80,6 @@ class RackTestApp < Minitest::Test
   end
 
   def test_must_return_xtrace_header
-    clear_all_traces
     get "/lobster"
     xtrace = last_response['X-Trace']
     assert xtrace
@@ -83,9 +87,6 @@ class RackTestApp < Minitest::Test
   end
 
   def test_log_args_when_false
-    clear_all_traces
-
-    @log_args = AppOpticsAPM::Config[:rack][:log_args]
     AppOpticsAPM::Config[:rack][:log_args] = false
 
     get "/lobster?blah=1"
@@ -98,13 +99,9 @@ class RackTestApp < Minitest::Test
 
     traces[0]['URL'].must_equal "/lobster"
 
-    AppOpticsAPM::Config[:rack][:log_args] = @log_args
   end
 
   def test_log_args_when_true
-    clear_all_traces
-
-    @log_args = AppOpticsAPM::Config[:rack][:log_args]
     AppOpticsAPM::Config[:rack][:log_args] = true
 
     get "/lobster?blah=1"
@@ -117,12 +114,9 @@ class RackTestApp < Minitest::Test
 
     traces[0]['URL'].must_equal "/lobster?blah=1"
 
-    AppOpticsAPM::Config[:rack][:log_args] = @log_args
   end
 
   def test_has_header_when_not_tracing
-    clear_all_traces
-
     AppOpticsAPM::Config[:tracing_mode] = :never
 
     get "/lobster?blah=1"
@@ -171,7 +165,6 @@ class RackTestApp < Minitest::Test
   end
 
   def test_exception
-    clear_all_traces
     get '/the_exception'
 
     traces = get_all_traces
@@ -182,5 +175,15 @@ class RackTestApp < Minitest::Test
     assert error_trace.key?('ErrorMsg')
     assert_equal 1, traces.select { |trace| trace['Label'] == 'error' }.count
   end
+
+  def test_without_backtrace
+    AppOpticsAPM::Config[:rack][:collect_backtraces] = false
+    get '/lobster'
+
+    traces = get_all_traces
+
+    refute traces[0]['Backtrace']
+  end
+
 end
 

--- a/test/instrumentation/rack_unit_test.rb
+++ b/test/instrumentation/rack_unit_test.rb
@@ -87,7 +87,7 @@ describe "Rack: " do
       end
     end
 
-    it " should log exit even when there is an exception" do
+    it "should log exit even when there is an exception" do
       AppOpticsAPM::API.expects(:log_exit)
 
       assert_raises StandardError do

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -38,7 +38,7 @@ describe "RestClient" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 9
+    traces.count.must_equal 8
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rest_client_test')
@@ -49,16 +49,16 @@ describe "RestClient" do
     traces[2]['Layer'].must_equal 'net-http'
     traces[2]['Label'].must_equal 'entry'
 
-    traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
-    traces[6]['HTTPMethod'].must_equal 'GET'
-    traces[6]['HTTPStatus'].must_equal "200"
-    traces[6].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
+    traces[5]['Layer'].must_equal 'net-http'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
+    traces[5]['HTTPMethod'].must_equal 'GET'
+    traces[5]['HTTPStatus'].must_equal "200"
+    traces[5].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[7]['Layer'].must_equal 'rest-client'
-    traces[7]['Label'].must_equal 'exit'
+    traces[6]['Layer'].must_equal 'rest-client'
+    traces[6]['Label'].must_equal 'exit'
 
     response.headers.key?(:x_trace).wont_equal nil
     xtrace = response.headers[:x_trace]
@@ -72,7 +72,7 @@ describe "RestClient" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 9
+    traces.count.must_equal 8
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rest_client_test')
@@ -83,16 +83,16 @@ describe "RestClient" do
     traces[2]['Layer'].must_equal 'net-http'
     traces[2]['Label'].must_equal 'entry'
 
-    traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?a=1'
-    traces[6]['HTTPMethod'].must_equal 'GET'
-    traces[6]['HTTPStatus'].must_equal "200"
-    traces[6].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
+    traces[5]['Layer'].must_equal 'net-http'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?a=1'
+    traces[5]['HTTPMethod'].must_equal 'GET'
+    traces[5]['HTTPStatus'].must_equal "200"
+    traces[5].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[7]['Layer'].must_equal 'rest-client'
-    traces[7]['Label'].must_equal 'exit'
+    traces[6]['Layer'].must_equal 'rest-client'
+    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace a raw POST request' do
@@ -101,7 +101,7 @@ describe "RestClient" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 9
+    traces.count.must_equal 8
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rest_client_test')
@@ -112,16 +112,16 @@ describe "RestClient" do
     traces[2]['Layer'].must_equal 'net-http'
     traces[2]['Label'].must_equal 'entry'
 
-    traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
-    traces[6]['HTTPMethod'].must_equal 'POST'
-    traces[6]['HTTPStatus'].must_equal "200"
-    traces[6].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
+    traces[5]['Layer'].must_equal 'net-http'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
+    traces[5]['HTTPMethod'].must_equal 'POST'
+    traces[5]['HTTPStatus'].must_equal "200"
+    traces[5].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[7]['Layer'].must_equal 'rest-client'
-    traces[7]['Label'].must_equal 'exit'
+    traces[6]['Layer'].must_equal 'rest-client'
+    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace a ActiveResource style GET request' do
@@ -131,7 +131,7 @@ describe "RestClient" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 9
+    traces.count.must_equal 8
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rest_client_test')
@@ -142,16 +142,16 @@ describe "RestClient" do
     traces[2]['Layer'].must_equal 'net-http'
     traces[2]['Label'].must_equal 'entry'
 
-    traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?a=1'
-    traces[6]['HTTPMethod'].must_equal 'GET'
-    traces[6]['HTTPStatus'].must_equal "200"
-    traces[6].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
+    traces[5]['Layer'].must_equal 'net-http'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/?a=1'
+    traces[5]['HTTPMethod'].must_equal 'GET'
+    traces[5]['HTTPStatus'].must_equal "200"
+    traces[5].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[7]['Layer'].must_equal 'rest-client'
-    traces[7]['Label'].must_equal 'exit'
+    traces[6]['Layer'].must_equal 'rest-client'
+    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace requests with redirects' do
@@ -161,7 +161,7 @@ describe "RestClient" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 16
+    traces.count.must_equal 14
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'rest_client_test')
@@ -172,33 +172,33 @@ describe "RestClient" do
     traces[2]['Layer'].must_equal 'net-http'
     traces[2]['Label'].must_equal 'entry'
 
-    traces[6]['Layer'].must_equal 'net-http'
-    traces[6]['Label'].must_equal 'exit'
-    traces[6]['IsService'].must_equal 1
-    traces[6]['RemoteURL'].must_equal 'http://127.0.0.1:8101/redirectme?redirect_test'
-    traces[6]['HTTPMethod'].must_equal 'GET'
-    traces[6]['HTTPStatus'].must_equal "301"
-    traces[6].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
+    traces[5]['Layer'].must_equal 'net-http'
+    traces[5]['Label'].must_equal 'exit'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/redirectme?redirect_test'
+    traces[5]['HTTPMethod'].must_equal 'GET'
+    traces[5]['HTTPStatus'].must_equal "301"
+    traces[5].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[7]['Layer'].must_equal 'rest-client'
+    traces[6]['Layer'].must_equal 'rest-client'
+    traces[6]['Label'].must_equal 'entry'
+
+    traces[7]['Layer'].must_equal 'net-http'
     traces[7]['Label'].must_equal 'entry'
 
-    traces[8]['Layer'].must_equal 'net-http'
-    traces[8]['Label'].must_equal 'entry'
+    traces[10]['Layer'].must_equal 'net-http'
+    traces[10]['Label'].must_equal 'exit'
+    traces[10]['IsService'].must_equal 1
+    traces[10]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
+    traces[10]['HTTPMethod'].must_equal 'GET'
+    traces[10]['HTTPStatus'].must_equal "200"
+    traces[10].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
 
-    traces[12]['Layer'].must_equal 'net-http'
+    traces[11]['Layer'].must_equal 'rest-client'
+    traces[11]['Label'].must_equal 'exit'
+
+    traces[12]['Layer'].must_equal 'rest-client'
     traces[12]['Label'].must_equal 'exit'
-    traces[12]['IsService'].must_equal 1
-    traces[12]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
-    traces[12]['HTTPMethod'].must_equal 'GET'
-    traces[12]['HTTPStatus'].must_equal "200"
-    traces[12].key?('Backtrace').must_equal !!AppOpticsAPM::Config[:nethttp][:collect_backtraces]
-
-    traces[13]['Layer'].must_equal 'rest-client'
-    traces[13]['Label'].must_equal 'exit'
-
-    traces[14]['Layer'].must_equal 'rest-client'
-    traces[14]['Label'].must_equal 'exit'
   end
 
   it 'should trace and capture raised exceptions' do

--- a/test/instrumentation/sidekiq-client_test.rb
+++ b/test/instrumentation/sidekiq-client_test.rb
@@ -45,7 +45,7 @@ unless defined?(JRUBY_VERSION)
       sleep 3
 
       traces = get_all_traces
-      assert_equal 20, refined_trace_count(traces)
+      assert_equal 16, refined_trace_count(traces)
       assert valid_edges?(traces, false), "Invalid edge in traces"
 
       assert_equal 'sidekiq-client',       traces[1]['Layer']
@@ -87,7 +87,7 @@ unless defined?(JRUBY_VERSION)
       sleep 3
 
       traces = get_all_traces
-      assert_equal 20, refined_trace_count(traces)
+      assert_equal 16, refined_trace_count(traces)
       assert valid_edges?(traces, false), "Invalid edge in traces"
       assert_equal 'sidekiq-client',   traces[1]['Layer']
       assert_equal false,              traces[1].key?('Backtrace')
@@ -105,7 +105,7 @@ unless defined?(JRUBY_VERSION)
       sleep 3
 
       traces = get_all_traces
-      assert_equal 20, refined_trace_count(traces)
+      assert_equal 16, refined_trace_count(traces)
       assert valid_edges?(traces, false), "Invalid edge in traces"
       assert_equal 'sidekiq-client',   traces[1]['Layer']
       assert_equal true,               traces[1].key?('Backtrace')
@@ -123,7 +123,7 @@ unless defined?(JRUBY_VERSION)
       sleep 3
 
       traces = get_all_traces
-      assert_equal 20, refined_trace_count(traces)
+      assert_equal 16, refined_trace_count(traces)
       assert valid_edges?(traces, false), "Invalid edge in traces"
       assert_equal false, traces[1].key?('Args')
     end
@@ -140,7 +140,7 @@ unless defined?(JRUBY_VERSION)
       sleep 3
 
       traces = get_all_traces
-      assert_equal 20, refined_trace_count(traces)
+      assert_equal 16, refined_trace_count(traces)
       assert valid_edges?(traces, false), "Invalid edge in traces"
       assert_equal true,         traces[1].key?('Args')
       assert_equal '[1, 2, 3]',  traces[1]['Args']
@@ -160,7 +160,7 @@ unless defined?(JRUBY_VERSION)
       # FIXME: the sidekiq worker is not respecting the AppOpticsAPM::Config[:tracing_mode] = 'never' setting
       # ____ instead of no traces we are getting 17, that is 4 less than we would get with tracing
       # assert_equal 0, traces.count
-      assert_equal 16, refined_trace_count(traces)
+      assert_equal 12, refined_trace_count(traces)
     end
   end
 end

--- a/test/instrumentation/sidekiq-worker_test.rb
+++ b/test/instrumentation/sidekiq-worker_test.rb
@@ -39,7 +39,7 @@ unless defined?(JRUBY_VERSION)
       sleep 5
 
       traces = get_all_traces
-      assert_equal 16, traces.count, "Trace count"
+      assert_equal 12, traces.count, "Trace count"
       validate_outer_layers(traces, "sidekiq-worker")
       assert valid_edges?(traces), "Invalid edge in traces"
 
@@ -62,11 +62,10 @@ unless defined?(JRUBY_VERSION)
       assert_equal "critical",            traces[0]['Queue']
       assert_equal "[1, 2, 3]",           traces[0]['Args']
       assert_equal "false",               traces[0]['Retry']
-
       assert_equal false,                 traces[0].key?('Backtrace')
       assert_equal "net-http",            traces[4]['Layer']
-      assert_equal "entry",               traces[4]['Label']
-      assert_equal "memcache",            traces[14]['Layer']
+      assert_equal "exit",               traces[4]['Label']
+      assert_equal "memcache",            traces[10]['Layer']
     end
 
     def test_jobs_with_errors
@@ -124,7 +123,7 @@ unless defined?(JRUBY_VERSION)
       sleep 5
 
       traces = get_all_traces
-      assert_equal 16, traces.count, "Trace count"
+      assert_equal 12, traces.count, "Trace count"
       assert valid_edges?(traces), "Invalid edge in traces"
       assert_equal 'sidekiq-worker',   traces[0]['Layer']
       assert_equal false,              traces[0].key?('Backtrace')
@@ -164,7 +163,7 @@ unless defined?(JRUBY_VERSION)
       sleep 5
 
       traces = get_all_traces
-      assert_equal 16, traces.count, "Trace count"
+      assert_equal 12, traces.count, "Trace count"
       assert valid_edges?(traces), "Invalid edge in traces"
       assert_equal false, traces[0].key?('Args')
     end
@@ -179,7 +178,7 @@ unless defined?(JRUBY_VERSION)
       sleep 5
 
       traces = get_all_traces
-      assert_equal 16, traces.count, "Trace count"
+      assert_equal 12, traces.count, "Trace count"
       assert valid_edges?(traces), "Invalid edge in traces"
       assert_equal true,         traces[0].key?('Args')
       assert_equal '[1, 2, 3]',  traces[0]['Args']

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -32,7 +32,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -40,13 +40,13 @@ describe "Typhoeus" do
     traces[1]['Layer'].must_equal 'typhoeus'
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
-    traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'exit'
-    traces[5]['Spec'].must_equal 'rsc'
-    traces[5]['IsService'].must_equal 1
-    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
-    traces[5]['HTTPMethod'].must_equal 'GET'
-    traces[5]['HTTPStatus'].must_equal 200
+    traces[4]['Layer'].must_equal 'typhoeus'
+    traces[4]['Label'].must_equal 'exit'
+    traces[4]['Spec'].must_equal 'rsc'
+    traces[4]['IsService'].must_equal 1
+    traces[4]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
+    traces[4]['HTTPMethod'].must_equal 'GET'
+    traces[4]['HTTPStatus'].must_equal 200
   end
 
   it 'should trace a typhoeus request to an uninstrumented app' do
@@ -79,7 +79,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -87,13 +87,13 @@ describe "Typhoeus" do
     traces[1]['Layer'].must_equal 'typhoeus'
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
-    traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'exit'
-    traces[5]['Spec'].must_equal 'rsc'
-    traces[5]['IsService'].must_equal 1
-    traces[5]['RemoteURL'].casecmp('http://127.0.0.1:8101/').must_equal 0
-    traces[5]['HTTPMethod'].must_equal 'POST'
-    traces[5]['HTTPStatus'].must_equal 200
+    traces[4]['Layer'].must_equal 'typhoeus'
+    traces[4]['Label'].must_equal 'exit'
+    traces[4]['Spec'].must_equal 'rsc'
+    traces[4]['IsService'].must_equal 1
+    traces[4]['RemoteURL'].casecmp('http://127.0.0.1:8101/').must_equal 0
+    traces[4]['HTTPMethod'].must_equal 'POST'
+    traces[4]['HTTPStatus'].must_equal 200
   end
 
   it 'should trace a typhoeus PUT request' do
@@ -103,7 +103,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -111,13 +111,13 @@ describe "Typhoeus" do
     traces[1]['Layer'].must_equal 'typhoeus'
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
-    traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'exit'
-    traces[5]['Spec'].must_equal 'rsc'
-    traces[5]['IsService'].must_equal 1
-    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
-    traces[5]['HTTPMethod'].must_equal 'PUT'
-    traces[5]['HTTPStatus'].must_equal 200
+    traces[4]['Layer'].must_equal 'typhoeus'
+    traces[4]['Label'].must_equal 'exit'
+    traces[4]['Spec'].must_equal 'rsc'
+    traces[4]['IsService'].must_equal 1
+    traces[4]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
+    traces[4]['HTTPMethod'].must_equal 'PUT'
+    traces[4]['HTTPStatus'].must_equal 200
   end
 
   it 'should trace a typhoeus DELETE request' do
@@ -126,7 +126,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -134,13 +134,13 @@ describe "Typhoeus" do
     traces[1]['Layer'].must_equal 'typhoeus'
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
-    traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'exit'
-    traces[5]['Spec'].must_equal 'rsc'
-    traces[5]['IsService'].must_equal 1
-    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
-    traces[5]['HTTPMethod'].must_equal 'DELETE'
-    traces[5]['HTTPStatus'].must_equal 200
+    traces[4]['Layer'].must_equal 'typhoeus'
+    traces[4]['Label'].must_equal 'exit'
+    traces[4]['Spec'].must_equal 'rsc'
+    traces[4]['IsService'].must_equal 1
+    traces[4]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
+    traces[4]['HTTPMethod'].must_equal 'DELETE'
+    traces[4]['HTTPStatus'].must_equal 200
   end
 
   it 'should trace a typhoeus HEAD request' do
@@ -149,7 +149,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -157,13 +157,13 @@ describe "Typhoeus" do
     traces[1]['Layer'].must_equal 'typhoeus'
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
-    traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'exit'
-    traces[5]['Spec'].must_equal 'rsc'
-    traces[5]['IsService'].must_equal 1
-    traces[5]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
-    traces[5]['HTTPMethod'].must_equal 'HEAD'
-    traces[5]['HTTPStatus'].must_equal 200
+    traces[4]['Layer'].must_equal 'typhoeus'
+    traces[4]['Label'].must_equal 'exit'
+    traces[4]['Spec'].must_equal 'rsc'
+    traces[4]['IsService'].must_equal 1
+    traces[4]['RemoteURL'].must_equal 'http://127.0.0.1:8101/'
+    traces[4]['HTTPMethod'].must_equal 'HEAD'
+    traces[4]['HTTPStatus'].must_equal 200
   end
 
   it 'should trace a typhoeus GET request to an instr\'d app' do
@@ -172,7 +172,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
 
     valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -180,13 +180,13 @@ describe "Typhoeus" do
     traces[1]['Layer'].must_equal 'typhoeus'
     traces[1].key?('Backtrace').must_equal AppOpticsAPM::Config[:typhoeus][:collect_backtraces]
 
-    traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'exit'
-    traces[5]['Spec'].must_equal 'rsc'
-    traces[5]['IsService'].must_equal 1
-    traces[5]['RemoteURL'].casecmp('http://127.0.0.1:8101/').must_equal 0
-    traces[5]['HTTPMethod'].must_equal 'GET'
-    traces[5]['HTTPStatus'].must_equal 200
+    traces[4]['Layer'].must_equal 'typhoeus'
+    traces[4]['Label'].must_equal 'exit'
+    traces[4]['Spec'].must_equal 'rsc'
+    traces[4]['IsService'].must_equal 1
+    traces[4]['RemoteURL'].casecmp('http://127.0.0.1:8101/').must_equal 0
+    traces[4]['HTTPMethod'].must_equal 'GET'
+    traces[4]['HTTPStatus'].must_equal 200
   end
 
   it 'should trace a typhoeus GET request with DNS error' do
@@ -235,7 +235,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 13
+    traces.count.must_equal 10
 
     valid_edges?(traces, false).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
@@ -244,8 +244,8 @@ describe "Typhoeus" do
     traces[1]['Label'].must_equal 'entry'
     traces[1]['Async'].must_equal 1
 
-    traces[11]['Layer'].must_equal 'typhoeus_hydra'
-    traces[11]['Label'].must_equal 'exit'
+    traces[8]['Layer'].must_equal 'typhoeus_hydra'
+    traces[8]['Label'].must_equal 'exit'
   end
 
   it 'should obey :log_args setting when true' do
@@ -256,8 +256,8 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
-    traces[5]['RemoteURL'].casecmp('http://127.0.0.1:8101/?blah=1').must_equal 0
+    traces.count.must_equal 6
+    traces[4]['RemoteURL'].casecmp('http://127.0.0.1:8101/?blah=1').must_equal 0
   end
 
   it 'should obey :log_args setting when false' do
@@ -268,8 +268,8 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
-    traces[5]['RemoteURL'].casecmp('http://127.0.0.1:8101/').must_equal 0
+    traces.count.must_equal 6
+    traces[4]['RemoteURL'].casecmp('http://127.0.0.1:8101/').must_equal 0
   end
 
   it 'should obey :collect_backtraces setting when true' do
@@ -280,7 +280,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
     layer_has_key(traces, 'typhoeus', 'Backtrace')
   end
 
@@ -292,7 +292,7 @@ describe "Typhoeus" do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 6
     layer_doesnt_have_key(traces, 'typhoeus', 'Backtrace')
   end
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -173,8 +173,8 @@ end
 #
 def validate_event_keys(event, kvs)
   kvs.each do |k, v|
-    assert_equal true, event.key?(k), "#{k} is missing"
-    assert event[k] == v, "#{k} != #{v} (#{event[k]})"
+    assert event.key?(k), "#{k} is missing"
+    assert_equal event[k], v, "#{k} != #{v} (#{event[k]})"
   end
 end
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -258,6 +258,23 @@ def layer_has_key(traces, layer, key)
 end
 
 ##
+# layer_has_key
+#
+# Checks an array of trace events if a specific layer (regardless of event type)
+# has he specified key
+#
+def layer_has_key_once(traces, layer, key)
+  return false if traces.empty?
+  has_keys = 0
+
+  traces.each do |t|
+    has_keys += 1 if t["Layer"] == layer and t.has_key?(key)
+  end
+
+  has_keys.must_equal 1, "Key #{key} missing in layer #{layer}"
+end
+
+##
 # layer_doesnt_have_key
 #
 # Checks an array of trace events to assure that a specific layer
@@ -271,7 +288,7 @@ def layer_doesnt_have_key(traces, layer, key)
     has_key = true if t["Layer"] == layer and t.has_key?(key)
   end
 
-  has_key.must_equal false
+  has_key.must_equal false, "Key #{key} should not be in layer #{layer}"
 end
 
 ##

--- a/test/run_tests/docker-compose.yml
+++ b/test/run_tests/docker-compose.yml
@@ -5,7 +5,8 @@ version: "2"
 # docker-compose to set up containers to run tests
 #
 # used by
-# > bundle exec tests
+# > rake docker
+# > rake docker_tests
 #
 ########################################################################################################
 

--- a/test/run_tests/docker-compose.yml
+++ b/test/run_tests/docker-compose.yml
@@ -37,6 +37,7 @@ services:
        - MYSQL_ROOT_PASSWORD=admin
        - MYSQL_HOST=mysql
        - APPOPTICS_MONGO_SERVER=mongo
+       - BUNDLE_GEMFILE=gemfiles/libraries.gemfile
 #       - SIMPLECOV_COVERAGE=True
 
 #  ruby_appoptics_apm_alpine:

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -165,7 +165,7 @@ class ConfigTest
 
       # Verify the number of individual instrumentations
       instrumentation = AppOpticsAPM::Config.instrumentation
-      instrumentation.count.must_equal 30
+      instrumentation.count.must_equal 32
 
       AppOpticsAPM::Config[:action_controller][:enabled].must_equal true
       AppOpticsAPM::Config[:action_controller_api][:enabled].must_equal true
@@ -183,10 +183,11 @@ class ConfigTest
       AppOpticsAPM::Config[:faraday][:enabled].must_equal true
       AppOpticsAPM::Config[:grape][:enabled].must_equal true
       AppOpticsAPM::Config[:httpclient][:enabled].must_equal true
-      AppOpticsAPM::Config[:nethttp][:enabled].must_equal true
       AppOpticsAPM::Config[:memcached][:enabled].must_equal true
       AppOpticsAPM::Config[:mongo][:enabled].must_equal true
       AppOpticsAPM::Config[:moped][:enabled].must_equal true
+      AppOpticsAPM::Config[:nethttp][:enabled].must_equal true
+      AppOpticsAPM::Config[:padrino][:enabled].must_equal true
       AppOpticsAPM::Config[:rack][:enabled].must_equal true
       AppOpticsAPM::Config[:redis][:enabled].must_equal true
       AppOpticsAPM::Config[:resqueclient][:enabled].must_equal true
@@ -195,6 +196,7 @@ class ConfigTest
       AppOpticsAPM::Config[:sequel][:enabled].must_equal true
       AppOpticsAPM::Config[:sidekiqclient][:enabled].must_equal true
       AppOpticsAPM::Config[:sidekiqworker][:enabled].must_equal true
+      AppOpticsAPM::Config[:sinatra][:enabled].must_equal true
       AppOpticsAPM::Config[:typhoeus][:enabled].must_equal true
 
       AppOpticsAPM::Config[:bunnyconsumer][:log_args].must_equal true
@@ -233,6 +235,7 @@ class ConfigTest
       AppOpticsAPM::Config[:mongo][:collect_backtraces].must_equal true
       AppOpticsAPM::Config[:moped][:collect_backtraces].must_equal true
       AppOpticsAPM::Config[:nethttp][:collect_backtraces].must_equal true
+      AppOpticsAPM::Config[:padrino][:collect_backtraces].must_equal true
       AppOpticsAPM::Config[:rack][:collect_backtraces].must_equal true
       AppOpticsAPM::Config[:redis][:collect_backtraces].must_equal false
       AppOpticsAPM::Config[:resqueclient][:collect_backtraces].must_equal true
@@ -241,6 +244,7 @@ class ConfigTest
       AppOpticsAPM::Config[:sequel][:collect_backtraces].must_equal true
       AppOpticsAPM::Config[:sidekiqclient][:collect_backtraces].must_equal false
       AppOpticsAPM::Config[:sidekiqworker][:collect_backtraces].must_equal false
+      AppOpticsAPM::Config[:sinatra][:collect_backtraces].must_equal true
       AppOpticsAPM::Config[:typhoeus][:collect_backtraces].must_equal false
     end
 

--- a/test/support/liboboe_settings_test.rb
+++ b/test/support/liboboe_settings_test.rb
@@ -38,7 +38,7 @@ unless defined?(JRUBY_VERSION)
       get "/lobster"
 
       traces = get_all_traces
-      traces.count.must_equal 3
+      traces.count.must_equal 2
 
       validate_outer_layers(traces, 'rack')
 


### PR DESCRIPTION
tried to clean up the use of `::` prepended to class/module names

It is needed when a class/module is called from within a class/module definition and the name should refer to the global namespace instead of within the current module.

[AO-10473 Ruby: Review use of `::` ](https://swicloud.atlassian.net/browse/AO-10473)