### PR TITLE
Fix: handle noop context in log_end

### DIFF
--- a/lib/appoptics_apm/api/logging.rb
+++ b/lib/appoptics_apm/api/logging.rb
@@ -194,7 +194,7 @@ module AppOpticsAPM
         log_event(layer, :exit, event, opts)
       ensure
         # FIXME has_incoming_context commented out, it has importance for JRuby only but breaks Ruby tests
-        AppOpticsAPM::Context.clear # unless AppOpticsAPM.has_incoming_context?
+        AppOpticsAPM::Context.try(:clear) # unless AppOpticsAPM.has_incoming_context?
         AppOpticsAPM.transaction_name = nil
       end
 


### PR DESCRIPTION
In case of AppOpticsAPM is not loaded (e.g. test environment without service key) there is an issue

Here: https://github.com/appoptics/appoptics-apm-ruby/blob/master/lib/appoptics_apm/api/logging.rb#L197

```ruby
def log_end(layer, opts = {}, event = nil)
  return AppOpticsAPM::Context.toString unless AppOpticsAPM.tracing?

  event ||= AppOpticsAPM::Context.createEvent
  log_event(layer, :exit, event, opts)
ensure
  # FIXME has_incoming_context commented out, it has importance for JRuby only but breaks Ruby tests
  AppOpticsAPM::Context.clear # unless AppOpticsAPM.has_incoming_context?
  AppOpticsAPM.transaction_name = nil
end
```

If there is no service key `return` will be called in the first row, but code in `ensure` block will be executed anyway
And the problem is that AppOpticsAPM::Context has no method `clear` because it is noop module (because if AppOpticsAPM not loaded then noop context will be required here: https://github.com/appoptics/appoptics-apm-ruby/blob/master/lib/appoptics_apm.rb#L63)