### PR TITLE
[noop] fix problem with log_end when in noop

### DIFF
--- a/lib/appoptics_apm.rb
+++ b/lib/appoptics_apm.rb
@@ -61,6 +61,7 @@ begin
     $stderr.puts 'Service Key may be wrong or missing.'
     $stderr.puts '=============================================================='
     require 'appoptics_apm/noop/context'
+    require 'appoptics_apm/noop/metadata'
   end
 
   # Load Ruby module last.  If there is no framework detected,

--- a/lib/appoptics_apm/noop/context.rb
+++ b/lib/appoptics_apm/noop/context.rb
@@ -7,13 +7,20 @@ module AppOpticsAPM
   module Context
 
     ##
-    # noop version of toString
+    # noop version of :toString
     # toString would return the current context (xtrace) as string
     #
     # the noop version returns an empty string
     #
     def self.toString
       ''
+    end
+
+    ##
+    # noop version of :clear
+    #
+    def self.clear
+
     end
   end
 end

--- a/lib/appoptics_apm/noop/metadata.rb
+++ b/lib/appoptics_apm/noop/metadata.rb
@@ -1,0 +1,22 @@
+####
+# noop version of AppOpticsAPM::Metadata
+#
+#
+
+module AppOpticsAPM
+  class Metadata
+
+    ##
+    # noop version of :makeRandom
+    #
+    # needs to return an object that responds to :isValid
+    #
+    def self.makeRandom
+      Metadata.new
+    end
+
+    def isValid
+      false
+    end
+  end
+end

--- a/test/noop/noop_test.rb
+++ b/test/noop/noop_test.rb
@@ -155,6 +155,20 @@ class NoopTest < Minitest::Test
     assert_equal 0, traces.count, "generate no traces"
   end
 
+  def test_log_init_doesnt_barf
+    AppOpticsAPM::API.log_init(nil, {:ok => :yeah })
+
+    traces = get_all_traces
+    assert_equal 0, traces.count, "generate no traces"
+  end
+
+  def test_log_end_doesnt_barf
+    AppOpticsAPM::API.log_end(nil, {:ok => :yeah })
+
+    traces = get_all_traces
+    assert_equal 0, traces.count, "generate no traces"
+  end
+
   def test_set_transaction_name_doesnt_barf
     AppOpticsAPM::API.set_transaction_name("should not throw an exception")
   end


### PR DESCRIPTION
This came to my attention thanks to a PR by adelnabiullin

The methods from the logging API aren't actually meant to be used outside of our instrumentation, but
since we can't control that, we need to make sure they don't break when in noop mode.

The current solution is to add noop versions of methods that are called when in noop.
In this case Context now gets :clear and Metadata gets :makeRandom and #isValid

[[AO-11841]](https://swicloud.atlassian.net/browse/AO-11841)