### PR TITLE
[oboe_init] new class for oboe init options with adaptations in other places

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The appoptics_apm gem provides [AppOptics APM](https://www.appoptics.com/) performance instrumentation for Ruby.
 
-![Ruby AppOpticsAPM](https://docs.appoptics.com/_images/ruby_trace.png)
+![Ruby AppOpticsAPM](https://docs.appoptics.com/_images/ruby_trace_smaller.png)
 
 It has the ability to report performance metrics on an array of libraries, databases and frameworks such as Rails, 
 Mongo, Memcache, ActiveRecord, Cassandra, Rack, Resque 

--- a/lib/appoptics_apm.rb
+++ b/lib/appoptics_apm.rb
@@ -21,6 +21,7 @@ begin
       require 'joboe_metal'
     elsif RUBY_PLATFORM =~ /linux/
       require_relative './oboe_metal.so'
+      require 'appoptics_apm/oboe_init_options'
       require 'oboe_metal.rb'  # sets AppOpticsAPM.loaded = true if successful
     else
       $stderr.puts '==================================================================='
@@ -46,8 +47,6 @@ begin
   require 'appoptics_apm/method_profiling'
 
   if AppOpticsAPM.loaded
-    # tracing mode is configured via config file but can only be set once we have oboe_metal loaded
-    AppOpticsAPM.set_tracing_mode(AppOpticsAPM::Config[:tracing_mode].to_sym)
     require 'appoptics_apm/instrumentation'
     require 'appoptics_apm/support/transaction_metrics'
 
@@ -59,7 +58,7 @@ begin
   else
     $stderr.puts '=============================================================='
     $stderr.puts 'AppOpticsAPM not loaded. Tracing disabled.'
-    $stderr.puts 'Service Key may be wrong or missing.'
+    $stderr.puts 'Service Key or other settings may be wrong or missing.'
     $stderr.puts '=============================================================='
     require 'appoptics_apm/noop/context'
     require 'appoptics_apm/noop/metadata'

--- a/lib/appoptics_apm.rb
+++ b/lib/appoptics_apm.rb
@@ -24,20 +24,20 @@ begin
       require 'appoptics_apm/oboe_init_options'
       require 'oboe_metal.rb'  # sets AppOpticsAPM.loaded = true if successful
     else
-      $stderr.puts '==================================================================='
-      $stderr.puts "AppOptics warning: Platform #{RUBY_PLATFORM} not yet supported."
-      $stderr.puts 'see: https://docs.appoptics.com/kb/apm_tracing/supported_platforms/'
-      $stderr.puts 'Tracing disabled.'
-      $stderr.puts 'Contact support@appoptics.com if this is unexpected.'
-      $stderr.puts '==================================================================='
+      AppOpticsAPM.logger.warn '==================================================================='
+      AppOpticsAPM.logger.warn "AppOptics warning: Platform #{RUBY_PLATFORM} not yet supported."
+      AppOpticsAPM.logger.warn 'see: https://docs.appoptics.com/kb/apm_tracing/supported_platforms/'
+      AppOpticsAPM.logger.warn 'Tracing disabled.'
+      AppOpticsAPM.logger.warn 'Contact support@appoptics.com if this is unexpected.'
+      AppOpticsAPM.logger.warn '==================================================================='
     end
   rescue LoadError => e
     unless ENV['RAILS_GROUP'] == 'assets' or ENV['IGNORE_APPOPTICS_WARNING']
-      $stderr.puts '=============================================================='
-      $stderr.puts 'Missing AppOpticsAPM libraries.  Tracing disabled.'
-      $stderr.puts "Error: #{e.message}"
-      $stderr.puts 'See: https://docs.appoptics.com/kb/apm_tracing/ruby/'
-      $stderr.puts '=============================================================='
+      AppOpticsAPM.logger.error '=============================================================='
+      AppOpticsAPM.logger.error 'Missing AppOpticsAPM libraries.  Tracing disabled.'
+      AppOpticsAPM.logger.error "Error: #{e.message}"
+      AppOpticsAPM.logger.error 'See: https://docs.appoptics.com/kb/apm_tracing/ruby/'
+      AppOpticsAPM.logger.error '=============================================================='
     end
   end
 
@@ -56,10 +56,11 @@ begin
     require 'appoptics_apm/frameworks/padrino'
     require 'appoptics_apm/frameworks/grape'
   else
-    $stderr.puts '=============================================================='
-    $stderr.puts 'AppOpticsAPM not loaded. Tracing disabled.'
-    $stderr.puts 'Service Key or other settings may be wrong or missing.'
-    $stderr.puts '=============================================================='
+    AppOpticsAPM.logger.warn '=============================================================='
+    AppOpticsAPM.logger.warn 'AppOpticsAPM not loaded. Tracing disabled.'
+    AppOpticsAPM.logger.warn 'There may be a problem with the service key or other settings.'
+    AppOpticsAPM.logger.warn 'Please check previous error messages.'
+    AppOpticsAPM.logger.warn '=============================================================='
     require 'appoptics_apm/noop/context'
     require 'appoptics_apm/noop/metadata'
   end

--- a/lib/appoptics_apm/base.rb
+++ b/lib/appoptics_apm/base.rb
@@ -21,12 +21,9 @@ SAMPLE_SOURCE_MASK = 0b1111000000000000000000000000
 # ZERO_SAMPLE_RATE_MASK   = 0b1111000000000000000000000000
 # ZERO_SAMPLE_SOURCE_MASK = 0b0000111111111111111111111111
 
-APPOPTICS_STR_BLANK = ''.freeze
+# APPOPTICS_STR_BLANK = ''.freeze
 APPOPTICS_STR_LAYER = 'Layer'.freeze
 APPOPTICS_STR_LABEL = 'Label'.freeze
-
-# Used in tests to store local trace data
-TRACE_FILE = '/tmp/appoptics_traces.bson'.freeze
 
 ##
 # This module is the base module for the various implementations of AppOpticsAPM reporting.

--- a/lib/appoptics_apm/config.rb
+++ b/lib/appoptics_apm/config.rb
@@ -239,15 +239,13 @@ module AppOpticsAPM
           @@config[i][:log_args] = value
         end
 
-      # Update liboboe if updating :tracing_mode
-      #
+      elsif key == :tracing_mode
       #   CAN'T DO THIS ANYMORE, ALL TRACING COMMUNICATION TO OBOE
       #   IS NOW HANDLED BY TransactionSettings
-      # elsif key == :tracing_mode
       #   AppOpticsAPM.set_tracing_mode(value.to_sym) if AppOpticsAPM.loaded
-      #
-      #   # Make sure that the mode is stored as a symbol
-      #   @@config[key.to_sym] = value.to_sym
+
+      # Make sure that the mode is stored as a symbol
+        @@config[key.to_sym] = value.to_sym
       end
     end
     # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity

--- a/lib/appoptics_apm/config.rb
+++ b/lib/appoptics_apm/config.rb
@@ -67,19 +67,22 @@ module AppOpticsAPM
         ].join(' ')
       end
       load(config_files[0])
-      check_env_vars
+      # sets AppOpticsAPM::Config[:debug_level], AppOpticsAPM.logger.level
+      set_log_level
+
+      # the verbose setting is only relevant for ruby, ENV['APPOPTICS_GEM_VERBOSE'] overrides
+      if ENV.key?('APPOPTICS_GEM_VERBOSE')
+        AppOpticsAPM::Config[:verbose] = ENV['APPOPTICS_GEM_VERBOSE'].downcase == 'true'
+      end
     end
 
-    # There are 4 variables that can be set in the config file or as env vars.
-    # Oboe will override vars passed in if it finds an environment variable
-    # :debug_level and :verbose need special consideration, because they are used in Ruby
-    def self.check_env_vars
+    def self.set_log_level
       unless (-1..6).include?(AppOpticsAPM::Config[:debug_level])
         AppOpticsAPM::Config[:debug_level] = 3
       end
 
-      # let's find and use the  equivalent debug level for ruby
-      debug_level = ENV['APPOPTICS_DEBUG_LEVEL'] ? ENV['APPOPTICS_DEBUG_LEVEL'].to_i : AppOpticsAPM::Config[:debug_level]
+      # let's find and use the equivalent debug level for ruby
+      debug_level = (ENV['APPOPTICS_DEBUG_LEVEL'] || AppOpticsAPM::Config[:debug_level] || 3).to_i
       if debug_level < 0
         # there should be no logging if APPOPTICS_DEBUG_LEVEL == -1
         # In Ruby level 5 is UNKNOWN and it can log, but level 6 is quiet
@@ -87,11 +90,7 @@ module AppOpticsAPM
       else
         AppOpticsAPM.logger.level = [4 - debug_level, 0].max
       end
-
-      # the verbose setting is only relevant for ruby, ENV['APPOPTICS_GEM_VERBOSE'] overrides
-      if ENV.key?('APPOPTICS_GEM_VERBOSE')
-        AppOpticsAPM::Config[:verbose] = ENV['APPOPTICS_GEM_VERBOSE'].downcase == 'true'
-      end
+      AppOpticsAPM::Config[:debug_level] = debug_level
     end
 
     ##
@@ -144,9 +143,6 @@ module AppOpticsAPM
       # no guarantee of completeness in the user's config file
       load(File.join(File.dirname(File.dirname(__FILE__)),
                     'rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb'))
-
-      # to make sure we include the service_key if it is set as an ENV var
-      check_env_vars
     end
     # rubocop:enable Metrics/AbcSize
 
@@ -244,11 +240,14 @@ module AppOpticsAPM
         end
 
       # Update liboboe if updating :tracing_mode
-      elsif key == :tracing_mode
-        AppOpticsAPM.set_tracing_mode(value.to_sym) if AppOpticsAPM.loaded
-
-        # Make sure that the mode is stored as a symbol
-        @@config[key.to_sym] = value.to_sym
+      #
+      #   CAN'T DO THIS ANYMORE, ALL TRACING COMMUNICATION TO OBOE
+      #   IS NOW HANDLED BY TransactionSettings
+      # elsif key == :tracing_mode
+      #   AppOpticsAPM.set_tracing_mode(value.to_sym) if AppOpticsAPM.loaded
+      #
+      #   # Make sure that the mode is stored as a symbol
+      #   @@config[key.to_sym] = value.to_sym
       end
     end
     # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity

--- a/lib/appoptics_apm/inst/sidekiq-worker.rb
+++ b/lib/appoptics_apm/inst/sidekiq-worker.rb
@@ -35,11 +35,12 @@ module AppOpticsAPM
       # args: 0: worker, 1: msg, 2: queue
       report_kvs = collect_kvs(args)
 
+      # TODO remove completely once it is determined that this works without
       # Something is happening across Celluloid threads where liboboe settings
       # are being lost.  So we re-set the tracing mode to assure
       # we sample as desired.  Setting the tracing mode will re-update
       # the liboboe settings.
-      AppOpticsAPM.set_tracing_mode(AppOpticsAPM::Config[:tracing_mode].to_sym)
+      # AppOpticsAPM.set_tracing_mode(AppOpticsAPM::Config[:tracing_mode].to_sym)
 
       # Continue the trace from the enqueue side?
       if args[1].is_a?(Hash) && AppOpticsAPM::XTrace.valid?(args[1]['SourceTrace'])

--- a/lib/appoptics_apm/oboe_init_options.rb
+++ b/lib/appoptics_apm/oboe_init_options.rb
@@ -121,7 +121,7 @@ module AppOpticsAPM
         @host = ENV['APPOPTICS_COLLECTOR'] || ''
       when 'udp'
         @host = ENV['APPOPTICS_COLLECTOR'] ||
-                "#{AppOpticsAPM::Config[:reporter_host]}:#{AppOpticsAPM::Config[:reporter_port]}" || ''
+                "#{AppOpticsAPM::Config[:reporter_host]}:#{AppOpticsAPM::Config[:reporter_port]}"
         # TODO decide what to do
         # ____ AppOpticsAPM::Config[:reporter_host] and
         # ____ AppOpticsAPM::Config[:reporter_port] were moved here from

--- a/lib/appoptics_apm/oboe_init_options.rb
+++ b/lib/appoptics_apm/oboe_init_options.rb
@@ -1,0 +1,135 @@
+# Copyright (c) 2019 SolarWinds, LLC.
+# All rights reserved.
+
+require 'singleton'
+
+module AppOpticsAPM
+
+  class OboeInitOptions
+    include Singleton
+
+    attr_reader :reporter, :host
+
+    # TODO decide if these globals are useful when testing
+    # OBOE_HOSTNAME_ALIAS = 0
+    # OBOE_DEBUG_LEVEL = 1
+    # OBOE_LOGFILE = 2
+    #
+    # OBOE_MAX_TRANSACTIONS = 3
+    # OBOE_FLUSH_MAX_WAIT_TIME = 4
+    # OBOE_EVENTS_FLUSH_INTERVAL = 5
+    # OBOE_EVENTS_FLUSH_BATCH_SIZE = 6
+    #
+    # OBOE_REPORTER = 7
+    # OBOE_COLLECTOR = 8
+    # OBOE_SERVICE_KEY = 9
+    # OBOE_TRUSTEDPATH = 10
+    #
+    # OBOE_BUFSIZE = 11
+    # OBOE_TRACE_METRICS = 12
+    # OBOE_HISTOGRAM_PRECISION = 13
+    # OBOE_TOKEN_BUCKET_CAPACITY = 14
+    # OBOE_TOKEN_BUCKET_RATE = 15
+    # OBOE_FILE_SINGLE = 16
+
+    def initialize
+      # optional hostname alias
+      @hostname_alias = ENV['APPOPTICS_HOSTNAME_ALIAS'] || AppOpticsAPM::Config[:hostname_alias] || ''
+      # level at which log messages will be written to log file (0-6)
+      @debug_level = (ENV['APPOPTICS_DEBUG_LEVEL'] || AppOpticsAPM::Config[:debug_level] || 3).to_i
+      # file name including path for log file
+      # TODO eventually find better way to combine ruby and oboe logs
+      @log_file_path = ENV['APPOPTICS_LOGFILE'] || ''
+      # maximum number of transaction names to track
+      @max_transactions = (ENV['APPOPTICS_MAX_TRANSACTIONS'] || -1).to_i
+      # maximum wait time for flushing data before terminating in milli seconds
+      @max_flush_wait_time = (ENV['APPOPTICS_FLUSH_MAX_WAIT_TIME'] || -1).to_i
+      # events flush timeout in seconds (threshold for batching messages before sending off)
+      @events_flush_interval = (ENV['APPOPTICS_EVENTS_FLUSH_INTERVAL'] || -1).to_i
+      # events flush batch size in KB (threshold for batching messages before sending off)
+      @event_flush_batch_size = (ENV['APPOPTICS_EVENTS_FLUSH_BATCH_SIZE'] || -1).to_i
+
+      # the reporter to be used (ssl, upd, file, null)
+      # collector endpoint (reporter=ssl), udp address (reporter=udp), or file path (reporter=file)
+      reporter_and_host # sets @reporter and @host
+
+      # the service key
+      @service_key = ENV['APPOPTICS_SERVICE_KEY'] || AppOpticsAPM::Config[:service_key] || ''
+      # path to the SSL certificate (only for ssl)
+      @trusted_path = ENV['APPOPTICS_TRUSTEDPATH'] || ''
+      # size of the message buffer
+      @buffer_size = (ENV['APPOPTICS_BUFSIZE'] || -1).to_i
+      # flag indicating if trace metrics reporting should be enabled (default) or disabled
+      @trace_metrics = (ENV['APPOPTICS_TRACE_METRICS'] || -1).to_i
+      # the histogram precision (only for ssl)
+      @histogram_precision = (ENV['APPOPTICS_HISTOGRAM_PRECISION'] || -1).to_i
+      # custom token bucket capacity
+      @token_bucket_capacity = (ENV['APPOPTICS_TOKEN_BUCKET_CAPACITY'] || -1).to_i
+      # custom token bucket rate
+      @token_bucket_rate = (ENV['APPOPTICS_TOKEN_BUCKET_RATE'] || -1).to_i
+      # use single files in file reporter for each event
+      @file_single = (ENV['APPOPTICS_REPORTER_FILE_SINGLE'].to_s.downcase == 'true') ? 1 : 0
+    end
+
+    def re_init # for testing with changed ENV vars
+      initialize
+    end
+
+    def array_for_oboe
+      [
+        @hostname_alias,
+        @debug_level,
+        @log_file_path,
+        @max_transactions,
+        @max_flush_wait_time,
+        @events_flush_interval,
+        @event_flush_batch_size,
+
+        @reporter,
+        @host,
+        @service_key,
+        @trusted_path,
+        @buffer_size,
+        @trace_metrics,
+        @histogram_precision,
+        @token_bucket_capacity,
+        @token_bucket_rate,
+        @file_single
+      ]
+    end
+
+    def service_key_ok?
+      # only required for ssl reporter
+      if @reporter == 'ssl' && @service_key !~ /^[0-9a-fA-F]{64}:[-.:_?\\\/\w ]{1,255}$/
+        AppOpticsAPM.logger.warn '[appoptics_apm/oboe_options] APPOPTICS_SERVICE_KEY problem. No service name or api token in wrong format. Cannot submit data.'
+        return false
+      end
+      true
+    end
+
+    private
+
+    def reporter_and_host
+
+      @reporter = ENV['APPOPTICS_REPORTER'] || 'ssl'
+      # override with 'file', e.g. when running tests
+      @reporter = 'file' if ENV.key?('APPOPTICS_GEM_TEST')
+
+      @host = ''
+      case @reporter
+      when 'ssl', 'file'
+        @host = ENV['APPOPTICS_COLLECTOR'] || ''
+      when 'udp'
+        @host = ENV['APPOPTICS_COLLECTOR'] ||
+                "#{AppOpticsAPM::Config[:reporter_host]}:#{AppOpticsAPM::Config[:reporter_port]}" || ''
+        # TODO decide what to do
+        # ____ AppOpticsAPM::Config[:reporter_host] and
+        # ____ AppOpticsAPM::Config[:reporter_port] were moved here from
+        # ____ oboe_metal.rb and are not documented anywhere
+      when 'null'
+        @host = ''
+      end
+
+    end
+  end
+end

--- a/lib/appoptics_apm/support/transaction_settings.rb
+++ b/lib/appoptics_apm/support/transaction_settings.rb
@@ -71,7 +71,7 @@ module AppOpticsAPM
     # check the config setting for :tracing_mode
     def tracing_mode_disabled?
       AppOpticsAPM::Config[:tracing_mode] &&
-        [:disabled, :never].include?(AppOpticsAPM::Config[:tracing_mode].to_sym)
+        [:disabled, :never].include?(AppOpticsAPM::Config[:tracing_mode])
     end
 
     ##

--- a/lib/appoptics_apm/support/transaction_settings.rb
+++ b/lib/appoptics_apm/support/transaction_settings.rb
@@ -17,7 +17,7 @@ AO_TRACING_DECISIONS_QUEUE_FULL = 5
 
 module AppOpticsAPM
   ##
-  # This module helps with setting up the filters and applying them
+  # This module helps with setting up the transaction filters and applying them
   #
   class TransactionSettings
 
@@ -40,8 +40,9 @@ module AppOpticsAPM
         return
       end
 
-      if AppOpticsAPM.tracing_disabled? && !tracing_enabled?(url) ||
+      if tracing_mode_disabled? && !tracing_enabled?(url) ||
         tracing_disabled?(url)
+
         tracing_mode = AO_TRACING_DISABLED
       end
 
@@ -65,6 +66,14 @@ module AppOpticsAPM
     end
 
     private
+
+    ##
+    # check the config setting for :tracing_mode
+    def tracing_mode_disabled?
+      AppOpticsAPM::Config[:tracing_mode] &&
+        [:disabled, :never].include?(AppOpticsAPM::Config[:tracing_mode].to_sym)
+    end
+
     ##
     # tracing_enabled?
     #

--- a/lib/appoptics_apm/version.rb
+++ b/lib/appoptics_apm/version.rb
@@ -7,7 +7,7 @@ module AppOpticsAPM
   # appoptics_apm.gemspec during gem build process
   module Version
     MAJOR = 4
-    MINOR = 7
+    MINOR = 8
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')

--- a/lib/oboe_metal.rb
+++ b/lib/oboe_metal.rb
@@ -75,12 +75,12 @@ module AppOpticsAPM
       def get_all_traces
         io = File.open(AppOpticsAPM::OboeInitOptions.instance.host, 'r')
         contents = io.readlines(nil)
+        io.close
 
         return contents if contents.empty?
 
         traces = []
 
-        #
         # We use Gem.loaded_spec because older versions of the bson
         # gem didn't even have a version embedded in the gem.  If the
         # gem isn't in the bundle, it should rightfully error out

--- a/test/instrumentation/bunny_consumer_test.rb
+++ b/test/instrumentation/bunny_consumer_test.rb
@@ -3,9 +3,9 @@
 
 require 'minitest_helper'
 
-unless defined?(JRUBY_VERSION)
-  class BunnyConsumerTest < Minitest::Test
-    def setup
+# unless defined?(JRUBY_VERSION)
+  describe 'BunnyConsumerTest' do
+    before do
       # Support specific environment variables to support remote rabbitmq servers
       ENV['APPOPTICS_RABBITMQ_SERVER'] = "127.0.0.1"      unless ENV['APPOPTICS_RABBITMQ_SERVER']
       ENV['APPOPTICS_RABBITMQ_PORT'] = "5672"             unless ENV['APPOPTICS_RABBITMQ_PORT']
@@ -23,7 +23,7 @@ unless defined?(JRUBY_VERSION)
       clear_all_traces
     end
 
-    def test_consume
+    it 'sends events when consuming' do
       @conn = Bunny.new(@connection_params)
       @conn.start
       @ch = @conn.create_channel
@@ -69,7 +69,7 @@ unless defined?(JRUBY_VERSION)
       @conn.close
     end
 
-    def test_blocking_consume
+    it 'sends event when consuming is blocked' do
       @conn = Bunny.new(@connection_params)
       @conn.start
       @ch = @conn.create_channel
@@ -115,7 +115,7 @@ unless defined?(JRUBY_VERSION)
       @conn.close
     end
 
-    def test_consumer_error_handling
+    it 'send event when there is an exception' do
       @conn = Bunny.new(@connection_params)
       @conn.start
       @ch = @conn.create_channel
@@ -160,7 +160,7 @@ unless defined?(JRUBY_VERSION)
       traces[2]['Label'].must_equal "exit"
     end
 
-    def test_message_id_capture
+    it 'captures the id' do
       @conn = Bunny.new(@connection_params)
       @conn.start
       @ch = @conn.create_channel
@@ -202,4 +202,3 @@ unless defined?(JRUBY_VERSION)
       @conn.close
     end
   end
-end

--- a/test/instrumentation/httpclient_test.rb
+++ b/test/instrumentation/httpclient_test.rb
@@ -1,332 +1,331 @@
 # Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
-unless defined?(JRUBY_VERSION)
+# unless defined?(JRUBY_VERSION)
   require 'minitest_helper'
   require 'appoptics_apm/inst/rack'
   require File.expand_path(File.dirname(__FILE__) + '../../frameworks/apps/sinatra_simple')
 
-  class HTTPClientTest < Minitest::Test
-    include Rack::Test::Methods
-
-    def app
-      SinatraSimple
-    end
-
-    def setup
-      clear_all_traces
-      AppOpticsAPM::Config[:tracing_mode] = :enabled
-    end
-
-    def teardown
-      clear_all_traces
-    end
-
-    def test_reports_version_init
-      init_kvs = ::AppOpticsAPM::Util.build_init_report
-      assert init_kvs.key?('Ruby.httpclient.Version')
-      assert_equal ::HTTPClient::VERSION, init_kvs['Ruby.httpclient.Version']
-    end
-
-    def test_get_request
-      AppOpticsAPM::API.start_trace('httpclient_tests') do
-        clnt = HTTPClient.new
-        response = clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
-
-        # Validate returned xtrace
-        assert response.headers.key?("X-Trace")
-        assert AppOpticsAPM::XTrace.valid?(response.headers["X-Trace"])
-      end
-
-      traces = get_all_traces
-      assert_equal 6, traces.count
-      assert valid_edges?(traces), "Invalid edge in traces"
-      validate_outer_layers(traces, "httpclient_tests")
-
-      assert_equal 'rsc', traces[1]['Spec']
-      assert_equal traces[1]['IsService'], 1
-      assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/?keyword=ruby&lang=en'
-      assert_equal traces[1]['HTTPMethod'], 'GET'
-
-      assert_equal traces[4]['Layer'], 'httpclient'
-      assert_equal traces[4]['Label'], 'exit'
-      assert_equal traces[4]['HTTPStatus'], 200
-      assert traces[4].key?('Backtrace')
-    end
-
-    def test_get_request_to_uninstr_app
-      AppOpticsAPM::API.start_trace('httpclient_tests') do
-        clnt = HTTPClient.new
-        response = clnt.get('http://127.0.0.1:8110/', :query => { :keyword => 'ruby', :lang => 'en' })
-        refute response.headers.key?("X-Trace")
-      end
-
-      traces = get_all_traces
-      assert_equal 4, traces.count
-      assert valid_edges?(traces), "Invalid edge in traces"
-      validate_outer_layers(traces, "httpclient_tests")
-
-      assert_equal 'rsc', traces[1]['Spec']
-      assert_equal traces[1]['IsService'], 1
-      assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8110/?keyword=ruby&lang=en'
-      assert_equal traces[1]['HTTPMethod'], 'GET'
-
-      assert_equal traces[2]['Layer'], 'httpclient'
-      assert_equal traces[2]['Label'], 'exit'
-      assert_equal traces[2]['HTTPStatus'], 200
-      assert traces[2].key?('Backtrace')
-    end
-
-    def test_get_with_header_hash
-      response = nil
-
-      AppOpticsAPM::API.start_trace('httpclient_tests') do
-        clnt = HTTPClient.new
-        response = clnt.get('http://127.0.0.1:8101/', nil, { "SOAPAction" => "HelloWorld" })
-      end
-
-      traces = get_all_traces
-      xtrace = response.headers['X-Trace']
-      assert xtrace
-      assert AppOpticsAPM::XTrace.valid?(xtrace)
-
-      assert_equal 6, traces.count
-      assert valid_edges?(traces), "Invalid edge in traces"
-      validate_outer_layers(traces, "httpclient_tests")
-
-      assert_equal 'rsc', traces[1]['Spec']
-      assert_equal traces[1]['IsService'], 1
-      assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/'
-      assert_equal traces[1]['HTTPMethod'], 'GET'
-
-      assert_equal traces[4]['Layer'], 'httpclient'
-      assert_equal traces[4]['Label'], 'exit'
-      assert_equal traces[4]['HTTPStatus'], 200
-      assert traces[4].key?('Backtrace')
-    end
-
-    def test_get_with_header_array
-      response = nil
-
-      AppOpticsAPM::API.start_trace('httpclient_tests') do
-        clnt = HTTPClient.new
-        response = clnt.get('http://127.0.0.1:8101/', nil, [["Accept", "text/plain"], ["Accept", "text/html"]])
-      end
-
-      traces = get_all_traces
-
-      xtrace = response.headers['X-Trace']
-      assert xtrace
-      assert AppOpticsAPM::XTrace.valid?(xtrace)
-
-      assert_equal 6, traces.count
-      assert valid_edges?(traces), "Invalid edge in traces"
-      validate_outer_layers(traces, "httpclient_tests")
-
-      assert_equal 'rsc', traces[1]['Spec']
-      assert_equal traces[1]['IsService'], 1
-      assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/'
-      assert_equal traces[1]['HTTPMethod'], 'GET'
-
-      assert_equal traces[4]['Layer'], 'httpclient'
-      assert_equal traces[4]['Label'], 'exit'
-      assert_equal traces[4]['HTTPStatus'], 200
-      assert traces[4].key?('Backtrace')
-    end
-
-    def test_post_request
-      response = nil
-
-      AppOpticsAPM::API.start_trace('httpclient_tests') do
-        clnt = HTTPClient.new
-        response = clnt.post('http://127.0.0.1:8101/')
-      end
-
-      traces = get_all_traces
-
-      xtrace = response.headers['X-Trace']
-      assert xtrace
-      assert AppOpticsAPM::XTrace.valid?(xtrace)
-
-      assert_equal 6, traces.count
-      assert valid_edges?(traces), "Invalid edge in traces"
-      validate_outer_layers(traces, "httpclient_tests")
-
-      assert_equal 'rsc', traces[1]['Spec']
-      assert_equal traces[1]['IsService'], 1
-      assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/'
-      assert_equal traces[1]['HTTPMethod'], 'POST'
-
-      assert_equal traces[4]['Layer'], 'httpclient'
-      assert_equal traces[4]['Label'], 'exit'
-      assert_equal traces[4]['HTTPStatus'], 200
-      assert traces[4].key?('Backtrace')
-    end
-
-    def test_async_get
-      conn = nil
-
-      AppOpticsAPM::API.start_trace('httpclient_tests') do
-        clnt = HTTPClient.new
-        conn = clnt.get_async('http://127.0.0.1:8101/?blah=1')
-      end
-
-      # Allow async request to finish
-      Thread.pass until conn.finished?
-
-      traces = get_all_traces
-
-      assert_equal 6, traces.count
-      assert valid_edges?(traces, false), "Invalid edge in traces"
-
-      # In the case of async the layers are not always ordered the same
-      # validate_outer_layers is not applicable, so we make sure we get the pair for 'httpclient_tests'
-      assert_equal 2, traces.select { |trace| trace['Layer'] == 'httpclient_tests' }.size
-
-      # because of possible different ordering of traces we can't rely on an index and need to use find
-      async_entry = traces.find { |trace| trace['Layer'] == 'httpclient' && trace['Label'] == 'entry' }
-      assert_equal 'rsc', async_entry['Spec']
-      assert_equal 1, async_entry['Async']
-      assert_equal 1, async_entry['IsService']
-      assert_equal 'http://127.0.0.1:8101/?blah=1', async_entry['RemoteURL']
-      assert_equal 'GET', async_entry['HTTPMethod']
-
-      assert_equal 'httpclient', traces[5]['Layer']
-      assert_equal 'exit', traces[5]['Label']
-      assert_equal 200, traces[5]['HTTPStatus']
-      assert traces[5].key?('Backtrace')
-    end
-
-    def test_cross_app_tracing
-      response = nil
-
-      AppOpticsAPM::API.start_trace('httpclient_tests') do
-        clnt = HTTPClient.new
-        response = clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
-      end
-
-      xtrace = response.headers['X-Trace']
-      assert xtrace
-      assert AppOpticsAPM::XTrace.valid?(xtrace)
-
-      traces = get_all_traces
-
-      assert_equal 6, traces.count
-      assert valid_edges?(traces), "Invalid edge in traces"
-      validate_outer_layers(traces, "httpclient_tests")
-
-      assert_equal 'rsc', traces[1]['Spec']
-      assert_equal 1, traces[1]['IsService']
-      assert_equal 'http://127.0.0.1:8101/?keyword=ruby&lang=en', traces[1]['RemoteURL']
-      assert_equal 'GET', traces[1]['HTTPMethod']
-
-      assert_equal 'rack', traces[2]['Layer']
-      assert_equal 'entry', traces[2]['Label']
-      assert_equal 'rack', traces[3]['Layer']
-      assert_equal 'exit', traces[3]['Label']
-
-      assert_equal 'httpclient', traces[4]['Layer']
-      assert_equal 'exit', traces[4]['Label']
-      assert_equal 200, traces[4]['HTTPStatus']
-      assert traces[4].key?('Backtrace')
-    end
-
-    def test_requests_with_errors
-      result = nil
-      begin
-        AppOpticsAPM::API.start_trace('httpclient_tests') do
-          clnt = HTTPClient.new
-          clnt.get('http://asfjalkfjlajfljkaljf/')
-        end
-      rescue
-      end
-
-      traces = get_all_traces
-      assert_equal 5, traces.count
-      assert valid_edges?(traces), "Invalid edge in traces"
-      validate_outer_layers(traces, "httpclient_tests")
-
-      assert_equal 'rsc', traces[1]['Spec']
-      assert_equal 1, traces[1]['IsService']
-      assert_equal 'http://asfjalkfjlajfljkaljf/', traces[1]['RemoteURL']
-      assert_equal 'GET', traces[1]['HTTPMethod']
-
-      assert_equal 'httpclient', traces[2]['Layer']
-      assert_equal 'error', traces[2]['Spec']
-      assert_equal 'error', traces[2]['Label']
-      assert_equal 1, traces.select { |trace| trace['Label'] == 'error' }.count
-
-      assert_equal "SocketError", traces[2]['ErrorClass']
-      assert traces[2].key?('ErrorMsg')
-      assert traces[2].key?('Backtrace')
-      assert_equal 1, traces.select { |trace| trace['Label'] == 'error' }.count
-
-      assert_equal 'httpclient', traces[3]['Layer']
-      assert_equal 'exit', traces[3]['Label']
-      assert traces[3].key?('Backtrace')
-    end
-
-    def test_log_args_when_true
-      @log_args = AppOpticsAPM::Config[:httpclient][:log_args]
-      AppOpticsAPM::Config[:httpclient][:log_args] = true
-
-      response = nil
-
-      AppOpticsAPM::API.start_trace('httpclient_tests') do
-        clnt = HTTPClient.new
-        response = clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
-      end
-
-      traces = get_all_traces
-
-      xtrace = response.headers['X-Trace']
-      assert xtrace
-      assert AppOpticsAPM::XTrace.valid?(xtrace)
-
-      assert_equal 6, traces.count
-      assert valid_edges?(traces), "Invalid edge in traces"
-
-      assert_equal 'http://127.0.0.1:8101/?keyword=ruby&lang=en', traces[1]['RemoteURL']
-
-      AppOpticsAPM::Config[:httpclient][:log_args] = @log_args
-    end
-
-    def test_log_args_when_false
-      @log_args = AppOpticsAPM::Config[:httpclient][:log_args]
-      AppOpticsAPM::Config[:httpclient][:log_args] = false
-
-      response = nil
-
-      AppOpticsAPM::API.start_trace('httpclient_tests') do
-        clnt = HTTPClient.new
-        response = clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
-      end
-
-      traces = get_all_traces
-
-      xtrace = response.headers['X-Trace']
-      assert xtrace
-      assert AppOpticsAPM::XTrace.valid?(xtrace)
-
-      assert_equal 6, traces.count
-      assert valid_edges?(traces), "Invalid edge in traces"
-
-      assert_equal 'http://127.0.0.1:8101/', traces[1]['RemoteURL']
-
-      AppOpticsAPM::Config[:httpclient][:log_args] = @log_args
-    end
-
-    def test_without_tracing
+describe 'HTTPClientTest' do
+  include Rack::Test::Methods
+
+  def app
+    SinatraSimple
+  end
+
+  before do
+    clear_all_traces
+    AppOpticsAPM::Config[:tracing_mode] = :enabled
+  end
+
+  after do
+    clear_all_traces
+  end
+
+  it 'identifies the version' do
+    init_kvs = ::AppOpticsAPM::Util.build_init_report
+    assert init_kvs.key?('Ruby.httpclient.Version')
+    assert_equal ::HTTPClient::VERSION, init_kvs['Ruby.httpclient.Version']
+  end
+
+  it 'sends event for a request' do
+    AppOpticsAPM::API.start_trace('httpclient_tests') do
       clnt = HTTPClient.new
-      clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
+      response = clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
 
-      traces = get_all_traces
-      # we only get traces from rack
-      assert_equal 2, traces.count
-      traces.each do |trace|
-        assert_equal 'rack', trace["Layer"]
-      end
-
+      # Validate returned xtrace
+      assert response.headers.key?("X-Trace")
+      assert AppOpticsAPM::XTrace.valid?(response.headers["X-Trace"])
     end
+
+    traces = get_all_traces
+    assert_equal 6, traces.count
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, "httpclient_tests")
+
+    assert_equal 'rsc', traces[1]['Spec']
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/?keyword=ruby&lang=en'
+    assert_equal traces[1]['HTTPMethod'], 'GET'
+
+    assert_equal traces[4]['Layer'], 'httpclient'
+    assert_equal traces[4]['Label'], 'exit'
+    assert_equal traces[4]['HTTPStatus'], 200
+    assert traces[4].key?('Backtrace')
+  end
+
+  it 'works with a request to an uninstrumented app' do
+    AppOpticsAPM::API.start_trace('httpclient_tests') do
+      clnt = HTTPClient.new
+      response = clnt.get('http://127.0.0.1:8110/', :query => { :keyword => 'ruby', :lang => 'en' })
+      refute response.headers.key?("X-Trace")
+    end
+
+    traces = get_all_traces
+    assert_equal 4, traces.count
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, "httpclient_tests")
+
+    assert_equal 'rsc', traces[1]['Spec']
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8110/?keyword=ruby&lang=en'
+    assert_equal traces[1]['HTTPMethod'], 'GET'
+
+    assert_equal traces[2]['Layer'], 'httpclient'
+    assert_equal traces[2]['Label'], 'exit'
+    assert_equal traces[2]['HTTPStatus'], 200
+    assert traces[2].key?('Backtrace')
+  end
+
+  it 'works with a header hash' do
+    response = nil
+
+    AppOpticsAPM::API.start_trace('httpclient_tests') do
+      clnt = HTTPClient.new
+      response = clnt.get('http://127.0.0.1:8101/', nil, { "SOAPAction" => "HelloWorld" })
+    end
+
+    traces = get_all_traces
+    xtrace = response.headers['X-Trace']
+    assert xtrace
+    assert AppOpticsAPM::XTrace.valid?(xtrace)
+
+    assert_equal 6, traces.count
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, "httpclient_tests")
+
+    assert_equal 'rsc', traces[1]['Spec']
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/'
+    assert_equal traces[1]['HTTPMethod'], 'GET'
+
+    assert_equal traces[4]['Layer'], 'httpclient'
+    assert_equal traces[4]['Label'], 'exit'
+    assert_equal traces[4]['HTTPStatus'], 200
+    assert traces[4].key?('Backtrace')
+  end
+
+  it 'works with a header array' do
+    response = nil
+
+    AppOpticsAPM::API.start_trace('httpclient_tests') do
+      clnt = HTTPClient.new
+      response = clnt.get('http://127.0.0.1:8101/', nil, [["Accept", "text/plain"], ["Accept", "text/html"]])
+    end
+
+    traces = get_all_traces
+
+    xtrace = response.headers['X-Trace']
+    assert xtrace
+    assert AppOpticsAPM::XTrace.valid?(xtrace)
+
+    assert_equal 6, traces.count
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, "httpclient_tests")
+
+    assert_equal 'rsc', traces[1]['Spec']
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/'
+    assert_equal traces[1]['HTTPMethod'], 'GET'
+
+    assert_equal traces[4]['Layer'], 'httpclient'
+    assert_equal traces[4]['Label'], 'exit'
+    assert_equal traces[4]['HTTPStatus'], 200
+    assert traces[4].key?('Backtrace')
+  end
+
+  it 'works for a post request' do
+    response = nil
+
+    AppOpticsAPM::API.start_trace('httpclient_tests') do
+      clnt = HTTPClient.new
+      response = clnt.post('http://127.0.0.1:8101/')
+    end
+
+    traces = get_all_traces
+
+    xtrace = response.headers['X-Trace']
+    assert xtrace
+    assert AppOpticsAPM::XTrace.valid?(xtrace)
+
+    assert_equal 6, traces.count
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, "httpclient_tests")
+
+    assert_equal 'rsc', traces[1]['Spec']
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteURL'], 'http://127.0.0.1:8101/'
+    assert_equal traces[1]['HTTPMethod'], 'POST'
+
+    assert_equal traces[4]['Layer'], 'httpclient'
+    assert_equal traces[4]['Label'], 'exit'
+    assert_equal traces[4]['HTTPStatus'], 200
+    assert traces[4].key?('Backtrace')
+  end
+
+  it 'works with an async get' do
+    conn = nil
+
+    AppOpticsAPM::API.start_trace('httpclient_tests') do
+      clnt = HTTPClient.new
+      conn = clnt.get_async('http://127.0.0.1:8101/?blah=1')
+    end
+
+    # Allow async request to finish
+    Thread.pass until conn.finished?
+
+    traces = get_all_traces
+
+    assert_equal 6, traces.count
+    assert valid_edges?(traces, false), "Invalid edge in traces"
+
+    # In the case of async the layers are not always ordered the same
+    # validate_outer_layers is not applicable, so we make sure we get the pair for 'httpclient_tests'
+    assert_equal 2, traces.select { |trace| trace['Layer'] == 'httpclient_tests' }.size
+
+    # because of possible different ordering of traces we can't rely on an index and need to use find
+    async_entry = traces.find { |trace| trace['Layer'] == 'httpclient' && trace['Label'] == 'entry' }
+    assert_equal 'rsc', async_entry['Spec']
+    assert_equal 1, async_entry['Async']
+    assert_equal 1, async_entry['IsService']
+    assert_equal 'http://127.0.0.1:8101/?blah=1', async_entry['RemoteURL']
+    assert_equal 'GET', async_entry['HTTPMethod']
+
+    assert_equal 'httpclient', traces[5]['Layer']
+    assert_equal 'exit', traces[5]['Label']
+    assert_equal 200, traces[5]['HTTPStatus']
+    assert traces[5].key?('Backtrace')
+  end
+
+  it 'works for cross app tracing' do
+    response = nil
+
+    AppOpticsAPM::API.start_trace('httpclient_tests') do
+      clnt = HTTPClient.new
+      response = clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
+    end
+
+    xtrace = response.headers['X-Trace']
+    assert xtrace
+    assert AppOpticsAPM::XTrace.valid?(xtrace)
+
+    traces = get_all_traces
+
+    assert_equal 6, traces.count
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, "httpclient_tests")
+
+    assert_equal 'rsc', traces[1]['Spec']
+    assert_equal 1, traces[1]['IsService']
+    assert_equal 'http://127.0.0.1:8101/?keyword=ruby&lang=en', traces[1]['RemoteURL']
+    assert_equal 'GET', traces[1]['HTTPMethod']
+
+    assert_equal 'rack', traces[2]['Layer']
+    assert_equal 'entry', traces[2]['Label']
+    assert_equal 'rack', traces[3]['Layer']
+    assert_equal 'exit', traces[3]['Label']
+
+    assert_equal 'httpclient', traces[4]['Layer']
+    assert_equal 'exit', traces[4]['Label']
+    assert_equal 200, traces[4]['HTTPStatus']
+    assert traces[4].key?('Backtrace')
+  end
+
+  it 'works when there are errors' do
+    result = nil
+    begin
+      AppOpticsAPM::API.start_trace('httpclient_tests') do
+        clnt = HTTPClient.new
+        clnt.get('http://asfjalkfjlajfljkaljf/')
+      end
+    rescue
+    end
+
+    traces = get_all_traces
+    assert_equal 5, traces.count
+    assert valid_edges?(traces), "Invalid edge in traces"
+    validate_outer_layers(traces, "httpclient_tests")
+
+    assert_equal 'rsc', traces[1]['Spec']
+    assert_equal 1, traces[1]['IsService']
+    assert_equal 'http://asfjalkfjlajfljkaljf/', traces[1]['RemoteURL']
+    assert_equal 'GET', traces[1]['HTTPMethod']
+
+    assert_equal 'httpclient', traces[2]['Layer']
+    assert_equal 'error', traces[2]['Spec']
+    assert_equal 'error', traces[2]['Label']
+    assert_equal 1, traces.select { |trace| trace['Label'] == 'error' }.count
+
+    assert_equal "SocketError", traces[2]['ErrorClass']
+    assert traces[2].key?('ErrorMsg')
+    assert traces[2].key?('Backtrace')
+    assert_equal 1, traces.select { |trace| trace['Label'] == 'error' }.count
+
+    assert_equal 'httpclient', traces[3]['Layer']
+    assert_equal 'exit', traces[3]['Label']
+    assert traces[3].key?('Backtrace')
+  end
+
+  it 'logs arguments when true' do
+    @log_args = AppOpticsAPM::Config[:httpclient][:log_args]
+    AppOpticsAPM::Config[:httpclient][:log_args] = true
+
+    response = nil
+
+    AppOpticsAPM::API.start_trace('httpclient_tests') do
+      clnt = HTTPClient.new
+      response = clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
+    end
+
+    traces = get_all_traces
+
+    xtrace = response.headers['X-Trace']
+    assert xtrace
+    assert AppOpticsAPM::XTrace.valid?(xtrace)
+
+    assert_equal 6, traces.count
+    assert valid_edges?(traces), "Invalid edge in traces"
+
+    assert_equal 'http://127.0.0.1:8101/?keyword=ruby&lang=en', traces[1]['RemoteURL']
+
+    AppOpticsAPM::Config[:httpclient][:log_args] = @log_args
+  end
+
+  it 'does not log args when false' do
+    @log_args = AppOpticsAPM::Config[:httpclient][:log_args]
+    AppOpticsAPM::Config[:httpclient][:log_args] = false
+
+    response = nil
+
+    AppOpticsAPM::API.start_trace('httpclient_tests') do
+      clnt = HTTPClient.new
+      response = clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
+    end
+
+    traces = get_all_traces
+
+    xtrace = response.headers['X-Trace']
+    assert xtrace
+    assert AppOpticsAPM::XTrace.valid?(xtrace)
+
+    assert_equal 6, traces.count
+    assert valid_edges?(traces), "Invalid edge in traces"
+
+    assert_equal 'http://127.0.0.1:8101/', traces[1]['RemoteURL']
+
+    AppOpticsAPM::Config[:httpclient][:log_args] = @log_args
+  end
+
+  it 'works without tracing context' do
+    clnt = HTTPClient.new
+    clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
+
+    traces = get_all_traces
+    # we only get traces from rack
+    assert_equal 2, traces.count
+    traces.each do |trace|
+      assert_equal 'rack', trace["Layer"]
+    end
+
   end
 end

--- a/test/instrumentation/sequel_mysql2_test.rb
+++ b/test/instrumentation/sequel_mysql2_test.rb
@@ -1,6 +1,7 @@
 # Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
+require 'appoptics_apm/test'
 require 'minitest_helper'
 
 if defined?(::Sequel) && !defined?(JRUBY_VERSION)

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -66,9 +66,10 @@ puts "\n\033[1m=== TEST RUN: #{RUBY_VERSION} #{File.basename(ENV['BUNDLE_GEMFILE
 
 ENV['RACK_ENV'] = 'test'
 
- # comment this out to send traces to the collector configured in `env`
- # make sure to set APPOPTICS_SERVICE_KEY
 ENV['APPOPTICS_GEM_TEST'] = 'true'
+ENV['APPOPTICS_REPORTER'] = 'file'
+ENV['APPOPTICS_COLLECTOR'] = '/tmp/appoptics_traces.bson'.freeze
+ENV['APPOPTICS_REPORTER_FILE_SINGLE'] = 'false'
 
 # ENV['APPOPTICS_GEM_VERBOSE'] = 'true'
 

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -4,7 +4,7 @@
 require 'minitest_helper'
 require 'mocha/minitest'
 
-class ConfigTest < Minitest::Test
+# class ConfigTest < Minitest::Test
   describe "AppOpticsAPM::Config" do
 
     @@default_config_path = File.join(Dir.pwd, 'appoptics_apm_config.rb')
@@ -121,49 +121,6 @@ class ConfigTest < Minitest::Test
        AppOpticsAPM.logger.level.must_equal Logger::WARN
        ENV['APPOPTICS_GEM_VERBOSE'].must_equal 'TRUE'
        AppOpticsAPM::Config[:verbose].must_equal true
-    end
-
-    it 'tests the env service key' do
-      AppOpticsAPM.logger.level = Logger::ERROR
-
-      ENV['APPOPTICS_SERVICE_KEY'] = nil
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal false
-
-      ENV['APPOPTICS_SERVICE_KEY'] = '22222222-2222-2222-2222-222222222222:service'
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal false
-
-      ENV['APPOPTICS_SERVICE_KEY'] = '1234567890123456789012345678901234567890123456789012345678901234'
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal false
-
-      ENV['APPOPTICS_SERVICE_KEY'] = '1234567890123456789012345678901234567890123456789012345678901234:'
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal false
-
-      ENV['APPOPTICS_SERVICE_KEY'] = '1234567890123456789012345678901234567890123456789012345678901234:service'
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal true
-    end
-
-    it 'tests the config service_key when there is no env' do
-      AppOpticsAPM.logger.level = Logger::ERROR
-      ENV['APPOPTICS_SERVICE_KEY'] = nil
-
-      AppOpticsAPM::Config[:service_key] = nil
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal false
-
-      AppOpticsAPM::Config[:service_key] = '22222222-2222-2222-2222-222222222222:service'
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal false
-
-      AppOpticsAPM::Config[:service_key] = '1234567890123456789012345678901234567890123456789012345678901234'
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal false
-
-      AppOpticsAPM::Config[:service_key] = '1234567890123456789012345678901234567890123456789012345678901234:'
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal false
-
-      AppOpticsAPM::Config[:service_key] = '1234567890123456789012345678901234567890123456789012345678901234:service'
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal true
-
-      ENV['APPOPTICS_SERVICE_KEY'] = 'blabla'
-      AppOpticsAPM::Config[:service_key] = '1234567890123456789012345678901234567890123456789012345678901234:service'
-      AppOpticsAPM::Reporter.valid_service_key?.must_equal false
     end
 
     it 'should use default when there is a wrong debug level setting' do
@@ -451,4 +408,4 @@ class ConfigTest < Minitest::Test
       AppOpticsAPM::Config.load_config_file
     end
   end
-end
+# end

--- a/test/support/sql_sanitize_test.rb
+++ b/test/support/sql_sanitize_test.rb
@@ -3,13 +3,13 @@
 
 require 'minitest_helper'
 
-class SQLSanitizeTest < Minitest::Test
+describe 'SQLSanitizeTest' do 
 
-  def teardown
+  before do
     AppOpticsAPM::Config[:sanitize_sql] = false
   end
 
-  def test_sanitize_sql1
+  it 'sanitizes an insert list' do
     AppOpticsAPM::Config[:sanitize_sql] = true
 
     sql = "INSERT INTO `queries` (`asdf_id`, `asdf_prices`, `created_at`, `updated_at`, `blue_pill`, `yearly_tax`, `rate`, `steam_id`, `red_pill`, `dimitri`, `origin`) VALUES (19231, 3, 'cat', 'dog', 111.0, 126.0, 116.0, 79.0, 72.0, 73.0, ?, 1, 3, 229.284, ?, ?, 100, ?, 0, 3, 1, ?, NULL, NULL, ?, 4, ?)"
@@ -17,7 +17,7 @@ class SQLSanitizeTest < Minitest::Test
     result.must_equal "INSERT INTO `queries` (`asdf_id`, `asdf_prices`, `created_at`, `updated_at`, `blue_pill`, `yearly_tax`, `rate`, `steam_id`, `red_pill`, `dimitri`, `origin`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
   end
 
-  def test_sanitize_sql2
+  it 'sanitizes a in list' do
     AppOpticsAPM::Config[:sanitize_sql] = true
 
     sql = "SELECT \"game_types\".* FROM \"game_types\" WHERE \"game_types\".\"game_id\" IN (1162)"
@@ -25,7 +25,7 @@ class SQLSanitizeTest < Minitest::Test
     result.must_equal "SELECT \"game_types\".* FROM \"game_types\" WHERE \"game_types\".\"game_id\" IN (?)"
   end
 
-  def test_sanitize_sql3
+  it 'sanitizes args in string' do
     AppOpticsAPM::Config[:sanitize_sql] = true
 
     sql = "SELECT \"comments\".* FROM \"comments\" WHERE \"comments\".\"commentable_id\" = 2798 AND \"comments\".\"commentable_type\" = 'Video' AND \"comments\".\"parent_id\" IS NULL ORDER BY comments.created_at DESC"
@@ -33,7 +33,7 @@ class SQLSanitizeTest < Minitest::Test
     result.must_equal "SELECT \"comments\".* FROM \"comments\" WHERE \"comments\".\"commentable_id\" = ? AND \"comments\".\"commentable_type\" = ? AND \"comments\".\"parent_id\" IS ? ORDER BY comments.created_at DESC"
   end
 
-  def test_sanitize_sql4
+  it 'sanitizes a mixture of situations' do
     AppOpticsAPM::Config[:sanitize_sql] = true
 
     sql = "SELECT `assets`.* FROM `assets` WHERE `assets`.`type` IN ('Picture') AND (updated_at >= '2015-07-08 19:22:00') AND (updated_at <= '2015-07-08 19:23:00') LIMIT 31 OFFSET 0"
@@ -41,7 +41,7 @@ class SQLSanitizeTest < Minitest::Test
     result.must_equal "SELECT `assets`.* FROM `assets` WHERE `assets`.`type` IN (?) AND (updated_at >= ?) AND (updated_at <= ?) LIMIT ? OFFSET ?"
   end
 
-  def test_sanitize_quoted_stuff1
+  it 'sanitizes quoted stuff' do
     AppOpticsAPM::Config[:sanitize_sql] = true
 
     sql = "SELECT `users`.* FROM `users` WHERE (mobile IN ('234 234 234') AND email IN ('a_b_c@hotmail.co.uk'))"
@@ -49,7 +49,7 @@ class SQLSanitizeTest < Minitest::Test
     result.must_equal "SELECT `users`.* FROM `users` WHERE (mobile IN (?) AND email IN (?))"
   end
 
-  def test_sanitize_quoted_stuff2
+  it 'sanitizes complicated quoted stuff' do
     AppOpticsAPM::Config[:sanitize_sql] = true
 
 
@@ -60,7 +60,7 @@ class SQLSanitizeTest < Minitest::Test
     result.must_equal "SELECT `users`.* FROM `users` WHERE (mobile IN (?) AND email IN (?)) LIMIT ?"
   end
 
-  def test_dont_sanitize
+  it 'does not sanitize when config is false' do
     AppOpticsAPM::Config[:sanitize_sql] = false
 
     sql = "SELECT `assets`.* FROM `assets` WHERE `assets`.`type` IN ('Picture') AND (updated_at >= '2015-07-08 19:22:00') AND (updated_at <= '2015-07-08 19:23:00') LIMIT 31 OFFSET 0"

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -1,3 +1,6 @@
+# Copyright (c) 2019 SolarWinds, LLC.
+# All rights reserved.
+
 require 'minitest_helper'
 require 'mocha/minitest'
 

--- a/test/unit/oboe_init_options_test.rb
+++ b/test/unit/oboe_init_options_test.rb
@@ -1,0 +1,182 @@
+# Copyright (c) 2019 SolarWinds, LLC.
+# All rights reserved.
+
+require 'minitest_helper'
+
+describe 'OboeInitOptions' do
+
+  before do
+    @env = ENV.to_hash
+    @log_level = AppOpticsAPM.logger.level
+  end
+
+  after do
+    @env.each { |k,v| ENV[k] = v }
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM.logger.level = @log_level
+  end
+
+  it 'sets all options from ENV vars' do
+    ENV['APPOPTICS_SERVICE_KEY'] = 'string_0'
+    ENV['APPOPTICS_REPORTER'] = 'udp'
+    ENV['APPOPTICS_COLLECTOR'] = 'string_2'
+    ENV['APPOPTICS_TRUSTEDPATH'] = 'string_3'
+    ENV['APPOPTICS_HOSTNAME_ALIAS'] = 'string_4'
+    ENV['APPOPTICS_BUFSIZE'] = '11'
+    ENV['APPOPTICS_LOGFILE'] = 'string_5'
+    ENV['APPOPTICS_DEBUG_LEVEL'] = '2'
+    ENV['APPOPTICS_TRACE_METRICS'] = '3'
+    ENV['APPOPTICS_HISTOGRAM_PRECISION'] = '4'
+    ENV['APPOPTICS_MAX_TRANSACTIONS'] = '5'
+    ENV['APPOPTICS_FLUSH_MAX_WAIT_TIME'] = '6'
+    ENV['APPOPTICS_EVENTS_FLUSH_INTERVAL'] = '7'
+    ENV['APPOPTICS_EVENTS_FLUSH_BATCH_SIZE'] = '8'
+    ENV['APPOPTICS_TOKEN_BUCKET_CAPACITY'] = '9'
+    ENV['APPOPTICS_TOKEN_BUCKET_RATE'] = '10'
+    ENV['APPOPTICS_REPORTER_FILE_SINGLE'] = 'True'
+
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    options = AppOpticsAPM::OboeInitOptions.instance.array_for_oboe
+
+    options.size.must_equal 17
+    options[0].must_equal 'string_4'
+    options[1].must_equal 2
+    options[2].must_equal 'string_5'
+    options[3].must_equal 5
+    options[4].must_equal 6
+    options[5].must_equal 7
+    options[6].must_equal 8
+    options[7].must_equal 'file'  # because we are testing
+    options[8].must_equal 'string_2'
+    options[9].must_equal 'string_0'
+    options[10].must_equal 'string_3'
+    options[11].must_equal 11
+    options[12].must_equal 3
+    options[13].must_equal 4
+    options[14].must_equal 9
+    options[15].must_equal 10
+    options[16].must_equal 1
+  end
+
+  it 'reads config vars' do
+    ENV.delete('APPOPTICS_HOSTNAME_ALIAS')
+    ENV.delete('APPOPTICS_DEBUG_LEVEL')
+    ENV.delete('APPOPTICS_SERVICE_KEY')
+
+    AppOpticsAPM::Config[:hostname_alias] = 'string_0'
+    AppOpticsAPM::Config[:debug_level] = 0
+    AppOpticsAPM::Config[:service_key] = 'string_1'
+
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    options = AppOpticsAPM::OboeInitOptions.instance.array_for_oboe
+
+    options.size.must_equal 17
+
+    options[0].must_equal 'string_0'
+    options[1].must_equal 0
+    options[9].must_equal 'string_1'
+  end
+
+  it 'env vars override config vars' do
+    ENV['APPOPTICS_HOSTNAME_ALIAS'] = 'string_0'
+    ENV['APPOPTICS_DEBUG_LEVEL'] = '1'
+    ENV['APPOPTICS_SERVICE_KEY'] = 'string_1'
+
+    AppOpticsAPM::Config[:hostname_alias] = 'string_2'
+    AppOpticsAPM::Config[:debug_level] = 2
+    AppOpticsAPM::Config[:service_key] = 'string_3'
+
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    options = AppOpticsAPM::OboeInitOptions.instance.array_for_oboe
+
+    options.size.must_equal 17
+
+    options[0].must_equal 'string_0'
+    options[1].must_equal 1
+    options[9].must_equal 'string_1'
+  end
+
+  it 'checks the service_key for ssl' do
+    ENV.delete('APPOPTICS_GEM_TEST')
+    ENV['APPOPTICS_REPORTER'] = 'ssl'
+    ENV['APPOPTICS_SERVICE_KEY'] = 'string_0'
+
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal false
+
+    ENV['APPOPTICS_SERVICE_KEY'] = '2895f613c0f452d6bc5dc000008f6754062689e224ec245926be520be0c00000:test_app'
+
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal true
+  end
+
+  it 'returns true for the service_key check for other reporters' do
+    ENV.delete('APPOPTICS_GEM_TEST')
+    ENV['APPOPTICS_REPORTER'] = 'udp'
+    ENV['APPOPTICS_SERVICE_KEY'] = 'string_0'
+
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal true
+
+    ENV['APPOPTICS_REPORTER'] = 'file'
+
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal true
+
+    ENV['APPOPTICS_REPORTER'] = 'null'
+
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal true
+  end
+
+  it 'validates the service key' do
+    AppOpticsAPM.logger.level = 6
+    ENV.delete('APPOPTICS_GEM_TEST')
+    ENV['APPOPTICS_REPORTER'] = 'ssl'
+    ENV['APPOPTICS_SERVICE_KEY'] = nil
+    AppOpticsAPM::Config[:service_key] = nil
+
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal false
+
+    AppOpticsAPM::Config[:service_key] = '22222222-2222-2222-2222-222222222222:service'
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal false
+
+    AppOpticsAPM::Config[:service_key] = '1234567890123456789012345678901234567890123456789012345678901234'
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal false
+
+    AppOpticsAPM::Config[:service_key] = '1234567890123456789012345678901234567890123456789012345678901234:'
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal false
+
+    AppOpticsAPM::Config[:service_key] = '1234567890123456789012345678901234567890123456789012345678901234:service'
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal true
+
+    ENV['APPOPTICS_SERVICE_KEY'] = 'blabla'
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal false
+
+    ENV['APPOPTICS_SERVICE_KEY'] = nil
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal true
+
+    ENV['APPOPTICS_SERVICE_KEY'] = '22222222-2222-2222-2222-222222222222:service'
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal false
+
+    ENV['APPOPTICS_SERVICE_KEY'] = '1234567890123456789012345678901234567890123456789012345678901234'
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal false
+
+    ENV['APPOPTICS_SERVICE_KEY'] = '1234567890123456789012345678901234567890123456789012345678901234:'
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal false
+
+    ENV['APPOPTICS_SERVICE_KEY'] = '1234567890123456789012345678901234567890123456789012345678901234:service'
+    AppOpticsAPM::OboeInitOptions.instance.re_init
+    AppOpticsAPM::OboeInitOptions.instance.service_key_ok?.must_equal true
+ end
+end


### PR DESCRIPTION
- the Singleton class OboeInitOptions collects and checks oboe options
- a few things were in Config and are now the responsibility of OboeInitOptions
- checking the service key has moved from oboe_metal to OboeInitOptions
- OboeMetal has been adapted
- Setting a global tracing mode has been removed, because TransactionSettings
  have to figure it out for each transaction since we added transaction filtering

[AO-12657]

[AO-12657]: https://swicloud.atlassian.net/browse/AO-12657