### PR TITLE
AO 13827 Rails 6 instrumentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ matrix:
       gemfile: gemfiles/rails42.gemfile
     - rvm: 2.6.4
       gemfile: gemfiles/rails42.gemfile
-
+    - rvm: 2.4.5
+      gemfile: gemfiles/rails60.gemfile
 
     - rmv: 2.6.4
       env: DBTYPE=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ gemfile:
   - gemfiles/instrumentation_mocked.gemfile
   - gemfiles/instrumentation_mocked_oldgems.gemfile
   - gemfiles/frameworks.gemfile
+  - gemfiles/rails60.gemfile
   - gemfiles/rails52.gemfile
   - gemfiles/rails42.gemfile
   - gemfiles/delayed_job.gemfile
@@ -57,9 +58,9 @@ matrix:
       env: DBTYPE=mysql
     - gemfile: gemfiles/frameworks.gemfile
       env: DBTYPE=mysql
-    - gemfile: gemfiles/rails51.gemfile
-      env: DBTYPE=mysql
     - gemfile: gemfiles/rails52.gemfile
+      env: DBTYPE=mysql
+    - gemfile: gemfiles/rails60.gemfile
       env: DBTYPE=mysql
     - gemfile: gemfiles/delayed_job.gemfile
       env: DBTYPE=mysql
@@ -96,9 +97,9 @@ matrix:
 #  - sudo service cassandra start
 
 install:
-  - curl -LO http://kent.dl.sourceforge.net/project/swig/swig/swig-3.0.8/swig-3.0.8.tar.gz
-  - tar xzf swig-3.0.8.tar.gz
-  - pushd swig-3.0.8
+  - curl -LO http://kent.dl.sourceforge.net/project/swig/swig/swig-3.0.8/swig-3.0.12.tar.gz
+  - tar xzf swig-3.0.12.tar.gz
+  - pushd swig-3.0.12
   - ./configure && make && sudo make install
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - DBTYPE=mysql
 
 rvm:
-  - 2.6.3
+  - 2.6.4
   - 2.5.5
   - 2.4.5
   - ruby-head
@@ -33,11 +33,11 @@ matrix:
   exclude:
     - rvm: ruby-head
       gemfile: gemfiles/rails42.gemfile
-    - rvm: 2.6.3
+    - rvm: 2.6.4
       gemfile: gemfiles/rails42.gemfile
 
 
-    - rmv: 2.6.3
+    - rmv: 2.6.4
       env: DBTYPE=mysql
     - rvm: 2.5.5
       env: DBTYPE=mysql
@@ -97,9 +97,9 @@ matrix:
 #  - sudo service cassandra start
 
 install:
-  - curl -LO http://kent.dl.sourceforge.net/project/swig/swig/swig-3.0.8/swig-3.0.12.tar.gz
-  - tar xzf swig-3.0.12.tar.gz
-  - pushd swig-3.0.12
+  - curl -LO http://kent.dl.sourceforge.net/project/swig/swig/swig-3.0.8/swig-3.0.8.tar.gz
+  - tar xzf swig-3.0.8.tar.gz
+  - pushd swig-3.0.8
   - ./configure && make && sudo make install
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,10 +112,8 @@ before_script:
   - export APPOPTICS_TOKEN_BUCKET_CAPACITY=1000
   - export APPOPTICS_TOKEN_BUCKET_RATE=1000
   - export OBOE_VERSION=5.1.1
-  - bundle update --jobs=3 --retry=3
-  - bundle exec rake fetch_ext_deps
-  - bundle exec rake clean
-  - bundle exec rake compile
+  - bundle --jobs=3 --retry=3
+  - bundle exec rake clean fetch compile
   - psql -c 'create database travis_ci_test;' -U postgres
   - mysql -e 'create database travis_ci_test;'
   - redis-server --requirepass secret_pass &

--- a/Rakefile
+++ b/Rakefile
@@ -66,13 +66,13 @@ end
 desc "Run all test suites defined by travis"
 task "docker_tests" do
   Dir.chdir('test/run_tests')
-  exec('docker-compose run ruby_appoptics /code/ruby-appoptics/test/run_tests/ruby_setup.sh test --remove-orphans')
+  exec('docker-compose run --rm ruby_appoptics /code/ruby-appoptics/test/run_tests/ruby_setup.sh test --remove-orphans')
 end
 
 desc "Start docker container for testing and debugging"
 task "docker" do
   Dir.chdir('test/run_tests')
-  exec('docker-compose run ruby_appoptics /code/ruby-appoptics/test/run_tests/ruby_setup.sh bash --remove-orphans')
+  exec('docker-compose run --rm ruby_appoptics /code/ruby-appoptics/test/run_tests/ruby_setup.sh bash --remove-orphans')
 end
 
 desc "Stop all containers that were started for testing and debugging"
@@ -84,11 +84,11 @@ end
 desc "Fetch extension dependency files"
 task :fetch_ext_deps do
   swig_version = %x{swig -version} rescue ''
-  swig_version = swig_version.scan(/swig version 3.0.\d*/i)
+  swig_version = swig_version.scan(/swig version [34]/i)
   if swig_version.empty?
     $stderr.puts '== ERROR ================================================================='
-    $stderr.puts "Could not find required swig version 3.0.*, found #{swig_version.inspect}"
-    $stderr.puts 'Please install swig "~ 3.0.8" and try again.'
+    $stderr.puts "Could not find required swig version >= 3.0.8, found #{swig_version.inspect}"
+    $stderr.puts 'Please install swig ">= 3.0.8" and try again.'
     $stderr.puts '=========================================================================='
     raise
   end

--- a/Rakefile
+++ b/Rakefile
@@ -128,6 +128,8 @@ task :fetch_ext_deps do
   end
 end
 
+task :fetch => :fetch_ext_deps
+
 desc "Build the gem's c extension"
 task :compile do
   if !defined?(JRUBY_VERSION)

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller.rb
@@ -84,10 +84,10 @@ module AppOpticsAPM
 end
 
 # ActionController::Base
-if defined?(ActionController::Base) && AppOpticsAPM::Config[:action_controller][:enabled] && Rails::VERSION::MAJOR < 6
+if defined?(ActionController::Base) && AppOpticsAPM::Config[:action_controller][:enabled] && Rails::VERSION::MAJOR <= 6
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting actioncontroller' if AppOpticsAPM::Config[:verbose]
   require "appoptics_apm/frameworks/rails/inst/action_controller#{Rails::VERSION::MAJOR}"
-  if Rails::VERSION::MAJOR == 5
+  if Rails::VERSION::MAJOR >= 5
     ActionController::Base.send(:prepend, ::AppOpticsAPM::Inst::ActionController)
   elsif Rails::VERSION::MAJOR < 5
     AppOpticsAPM::Util.send_include(::ActionController::Base, AppOpticsAPM::Inst::ActionController)
@@ -95,7 +95,7 @@ if defined?(ActionController::Base) && AppOpticsAPM::Config[:action_controller][
 end
 
 # ActionController::API - Rails 5 or via the rails-api gem
-if defined?(ActionController::API) && AppOpticsAPM::Config[:action_controller_api][:enabled]  && Rails::VERSION::MAJOR < 6
+if defined?(ActionController::API) && AppOpticsAPM::Config[:action_controller_api][:enabled]  && Rails::VERSION::MAJOR <= 6
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting actioncontroller api' if AppOpticsAPM::Config[:verbose]
   require "appoptics_apm/frameworks/rails/inst/action_controller_api"
   ActionController::API.send(:prepend, ::AppOpticsAPM::Inst::ActionControllerAPI)

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller6.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller6.rb
@@ -1,0 +1,50 @@
+# Copyright (c) 2016 SolarWinds, LLC.
+# All rights reserved.
+
+module AppOpticsAPM
+  module Inst
+    #
+    # ActionController
+    #
+    # This modules contains the instrumentation code specific
+    # to Rails v5
+    #
+    module ActionController
+      include AppOpticsAPM::Inst::RailsBase
+
+      def process_action(method_name, *args)
+        kvs = {
+            :Controller   => self.class.name,
+            :Action       => self.action_name,
+        }
+        request.env['appoptics_apm.controller'] = kvs[:Controller]
+        request.env['appoptics_apm.action'] = kvs[:Action]
+
+        return super(method_name, *args) unless AppOpticsAPM.tracing?
+        begin
+          kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:action_controller][:collect_backtraces]
+
+          AppOpticsAPM::API.log_entry('rails', kvs)
+          super(method_name, *args)
+
+        rescue Exception => e
+          AppOpticsAPM::API.log_exception('rails', e) if log_rails_error?(e)
+          raise
+        ensure
+          AppOpticsAPM::API.log_exit('rails')
+        end
+      end
+
+      #
+      # render
+      #
+      # Our render wrapper that calls 'trace', which will log if we are tracing
+      #
+      def render(*args, &blk)
+        trace('actionview') do
+          super(*args, &blk)
+        end
+      end
+    end
+  end
+end

--- a/lib/appoptics_apm/frameworks/rails/inst/action_controller6.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_controller6.rb
@@ -7,7 +7,7 @@ module AppOpticsAPM
     # ActionController
     #
     # This modules contains the instrumentation code specific
-    # to Rails v5
+    # to Rails v6
     #
     module ActionController
       include AppOpticsAPM::Inst::RailsBase

--- a/lib/appoptics_apm/frameworks/rails/inst/active_record.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/active_record.rb
@@ -5,13 +5,13 @@ require 'appoptics_apm/frameworks/rails/inst/connection_adapters/mysql'
 require 'appoptics_apm/frameworks/rails/inst/connection_adapters/mysql2'
 require 'appoptics_apm/frameworks/rails/inst/connection_adapters/postgresql'
 
-if AppOpticsAPM::Config[:active_record][:enabled] && !defined?(JRUBY_VERSION) && Rails::VERSION::MAJOR < 6
+if AppOpticsAPM::Config[:active_record][:enabled] && !defined?(JRUBY_VERSION) && Rails::VERSION::MAJOR <= 6
   begin
     adapter = ActiveRecord::Base.connection_config[:adapter]
 
     if Rails::VERSION::MAJOR < 5
       require 'appoptics_apm/frameworks/rails/inst/connection_adapters/utils'
-    elsif Rails::VERSION::MAJOR == 5
+    elsif Rails::VERSION::MAJOR >= 5
       require 'appoptics_apm/frameworks/rails/inst/connection_adapters/utils5x'
     end
 

--- a/test/frameworks/rails5x_test.rb
+++ b/test/frameworks/rails5x_test.rb
@@ -162,7 +162,8 @@ if defined?(::Rails)
 
       entry_traces[3]['Layer'].must_equal "activerecord"
       entry_traces[3]['Flavor'].must_equal "mysql"
-      entry_traces[3]['Query'].must_equal "SELECT  `widgets`.* FROM `widgets` WHERE `widgets`.`name` = 'blah' ORDER BY `widgets`.`id` ASC LIMIT 1"
+      # using match because there is a 1 space difference between Rails 5 and Rails 6
+      entry_traces[3]['Query'].must_match /SELECT\s{1,2}`widgets`.* FROM `widgets` WHERE `widgets`.`name` = 'blah' ORDER BY `widgets`.`id` ASC LIMIT 1/
       entry_traces[3]['Name'].must_equal "Widget Load"
       entry_traces[3].key?('Backtrace').must_equal false
       entry_traces[3].key?('QueryArgs').must_equal Rails.version < '5.2.0' ? true : false
@@ -204,7 +205,7 @@ if defined?(::Rails)
 
       entry_traces[3]['Layer'].must_equal "activerecord"
       entry_traces[3]['Flavor'].must_equal "mysql"
-      entry_traces[3]['Query'].must_equal "SELECT  `widgets`.* FROM `widgets` WHERE `widgets`.`name` = ? ORDER BY `widgets`.`id` ASC LIMIT ?"
+      entry_traces[3]['Query'].must_match /SELECT\s{1,2}`widgets`.* FROM `widgets` WHERE `widgets`.`name` = \? ORDER BY `widgets`.`id` ASC LIMIT \?/
       entry_traces[3]['Name'].must_equal "Widget Load"
       entry_traces[3].key?('Backtrace').must_equal false
       entry_traces[3].key?('QueryArgs').must_equal false

--- a/test/frameworks/rails5x_test.rb
+++ b/test/frameworks/rails5x_test.rb
@@ -102,7 +102,8 @@ if defined?(::Rails)
       traces[4]['Layer'].must_equal "activerecord"
       traces[4]['Label'].must_equal "entry"
       traces[4]['Flavor'].must_equal "postgresql"
-      traces[4]['Query'].must_equal "SELECT  \"widgets\".* FROM \"widgets\" WHERE \"widgets\".\"name\" = $? ORDER BY \"widgets\".\"id\" ASC LIMIT $?"
+      # using match because there is a 1 space difference between Rails 5 and Rails 6
+      traces[4]['Query'].must_match /SELECT\s{1,2}\"widgets\".* FROM \"widgets\" WHERE \"widgets\".\"name\" = \$\? ORDER BY \"widgets\".\"id\" ASC LIMIT \$\?/
       traces[4]['Name'].must_equal "Widget Load"
       traces[4].key?('Backtrace').must_equal false
       traces[4].key?('QueryArgs').must_equal false

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -106,8 +106,9 @@ when /delayed_job/
   require './test/servers/delayed_job'
 
 when /rails[56]/
-  require './test/servers/rails5x_api_8150'
   require './test/servers/rails5x_8140'
+  sleep 1
+  require './test/servers/rails5x_api_8150'
 when /rails4/
   require './test/servers/rails4x_8140'
 

--- a/test/run_tests/Dockerfile_test
+++ b/test/run_tests/Dockerfile_test
@@ -39,6 +39,7 @@ RUN  git clone https://github.com/rbenv/rbenv.git ~/.rbenv \
 
 # install rubies to build our gem against
 RUN . ~/.profile \
+    && cd /root/.rbenv/plugins/ruby-build && git pull && cd - \
     && rbenv install 2.4.5 \
     && rbenv install 2.5.5 \
     && rbenv install 2.6.4

--- a/test/run_tests/Dockerfile_test
+++ b/test/run_tests/Dockerfile_test
@@ -41,13 +41,13 @@ RUN  git clone https://github.com/rbenv/rbenv.git ~/.rbenv \
 RUN . ~/.profile \
     && rbenv install 2.4.5 \
     && rbenv install 2.5.5 \
-    && rbenv install 2.6.3
+    && rbenv install 2.6.4
 #    && rbenv install jruby-9.1.16.0
 
 # need to revert to using bundler 1.17.3 because some gems require bundler < 2.0
 RUN . ~/.profile && rbenv local 2.4.5 && gem uninstall bundler --quiet -x && gem install bundler -v 1.17.3
 RUN . ~/.profile && rbenv local 2.5.5 && gem uninstall bundler --quiet -x && gem install bundler -v 1.17.3
-RUN . ~/.profile && rbenv local 2.6.3 && gem uninstall bundler --quiet -x && gem install bundler -v 1.17.3
+RUN . ~/.profile && rbenv local 2.6.4 && gem uninstall bundler --quiet -x && gem install bundler -v 1.17.3
 
 RUN echo 'gem: --no-document' >> ~/.gemrc
 

--- a/test/run_tests/Dockerfile_test
+++ b/test/run_tests/Dockerfile_test
@@ -23,6 +23,7 @@ RUN apt-get update \
        libpq-dev \
        vim \
        less \
+       tcl \
        tree \
        psmisc \
     && rm -rf /var/lib/apt/lists/*
@@ -60,10 +61,14 @@ RUN curl -SL http://kent.dl.sourceforge.net/project/swig/swig/swig-4.0.0/swig-4.
     && cd - \
     && rm -rf /tmp/swig-4.0.0
 
-# install postgres, redis, and memcached
+# install redis-server version 4++
+RUN curl -SL http://download.redis.io/releases/redis-4.0.0.tar.gz | tar xzC /tmp \
+    && cd /tmp/redis-4.0.0/ \
+    && make  && make install && cd -
+
+# install postgres and memcached
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-       redis-server \
        memcached \
        postgresql \
        postgresql-contrib \

--- a/test/run_tests/docker-compose.yml
+++ b/test/run_tests/docker-compose.yml
@@ -70,10 +70,6 @@ services:
   ao-ruby-rabbitmq:
     container_name: ao-ruby-rabbitmq
     image: rabbitmq:3-management
-#    ports:
-#      - "8080:15672"
-#      - "5672:5672"
-#      - "5671:5671"
 
   ao-ruby-mysql:
     container_name: ao-ruby-mysql
@@ -81,14 +77,10 @@ services:
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_ROOT_PASSWORD=admin
-#    ports:
-#      - "3306:3306"
 
   ao-ruby-mongo:
     container_name: ao-ruby-mongo
     image: mongo:3.4
-#    ports:
-#      - "27017:27017"
 
   ao_ruby_wait:
     container_name: ao_ruby_wait
@@ -101,6 +93,4 @@ services:
       - ao-ruby-rabbitmq
       - ao-ruby-mysql
       - ao-ruby-mongo
-#    environment:
-#      - TARGETS=ao-ruby-mysql:3306;ao-ruby-rabbitmq:5672;ao-ruby-mongo:27017
 

--- a/test/servers/rails5x_8140.rb
+++ b/test/servers/rails5x_8140.rb
@@ -49,7 +49,7 @@ class Rails50MetalStack < Rails::Application
   config.middleware.delete ActionDispatch::Flash
   config.secret_token = "49837489qkuweoiuoqwehisuakshdjksadhaisdy78o34y138974xyqp9rmye8yrpiokeuioqwzyoiuxftoyqiuxrhm3iou1hrzmjk"
   config.secret_key_base = "2048671-96803948"
-  config.sqlite3 = {} # deal with https://github.com/rails/rails/issues/37048
+  config.active_record.sqlite3 = {} # deal with https://github.com/rails/rails/issues/37048
 end
 
 class ApplicationController < ActionController::Base

--- a/test/servers/rails5x_8140.rb
+++ b/test/servers/rails5x_8140.rb
@@ -49,6 +49,7 @@ class Rails50MetalStack < Rails::Application
   config.middleware.delete ActionDispatch::Flash
   config.secret_token = "49837489qkuweoiuoqwehisuakshdjksadhaisdy78o34y138974xyqp9rmye8yrpiokeuioqwzyoiuxftoyqiuxrhm3iou1hrzmjk"
   config.secret_key_base = "2048671-96803948"
+  config.sqlite3 = {} # deal with https://github.com/rails/rails/issues/37048
 end
 
 class ApplicationController < ActionController::Base

--- a/test/servers/rails5x_api_8150.rb
+++ b/test/servers/rails5x_api_8150.rb
@@ -52,7 +52,7 @@ module Rails50APIStack
     config.middleware.delete ActionDispatch::Flash
     config.secret_token = "48837489qkuweoiuoqwehisuakshdjksadhaisdy78o34y138974xyqp9rmye8yrpiokeuioqwzyoiuxftoyqiuxrhm3iou1hrzmjk"
     config.secret_key_base = "2049671-96803948"
-    config.sqlite3 = {} # deal with https://github.com/rails/rails/issues/37048
+    config.active_record.sqlite3 = {} # deal with https://github.com/rails/rails/issues/37048
   end
 end
 

--- a/test/servers/rails5x_api_8150.rb
+++ b/test/servers/rails5x_api_8150.rb
@@ -52,6 +52,7 @@ module Rails50APIStack
     config.middleware.delete ActionDispatch::Flash
     config.secret_token = "48837489qkuweoiuoqwehisuakshdjksadhaisdy78o34y138974xyqp9rmye8yrpiokeuioqwzyoiuxftoyqiuxrhm3iou1hrzmjk"
     config.secret_key_base = "2049671-96803948"
+    config.sqlite3 = {} # deal with https://github.com/rails/rails/issues/37048
   end
 end
 


### PR DESCRIPTION
This PR is to instrument the same layers in Rails 6 as we did in Rails 5, so that users that upgrade see the same traces.

- Code changes were required only when the Rails version gets checked.
- Includes some tweaks to the test env.