### PR TITLE
Ao 14676 graphql 2nd PR with a few tweaks

### DIFF
--- a/examples/SDK/01_basic_tracing.rb
+++ b/examples/SDK/01_basic_tracing.rb
@@ -7,7 +7,7 @@
 # `bundle exec ruby 01_basic_tracing.rb`
 
 require 'appoptics_apm'
-unless AppopticsAPM::SDK.appoptics_ready?(10_000)
+unless AppOpticsAPM::SDK.appoptics_ready?(10_000)
   puts "aborting!!! Agent not ready after 10 seconds"
   exit false
 end

--- a/gemfiles/frameworks.gemfile
+++ b/gemfiles/frameworks.gemfile
@@ -17,7 +17,7 @@ else
   gem 'sinatra'
 end
 
-gem 'rack', '~> 2.0.8'
+gem 'rack' # , '~> 2.0.8'
 gem 'grape'
 
 if defined?(JRUBY_VERSION)

--- a/gemfiles/frameworks.gemfile
+++ b/gemfiles/frameworks.gemfile
@@ -17,6 +17,7 @@ else
   gem 'sinatra'
 end
 
+gem 'rack', '~> 2.0.8'
 gem 'grape'
 
 if defined?(JRUBY_VERSION)

--- a/lib/appoptics_apm/api/util.rb
+++ b/lib/appoptics_apm/api/util.rb
@@ -24,15 +24,14 @@ module AppOpticsAPM
 
       # Internal: Get the current backtrace.
       #
-      # ignore - Number of frames to ignore at the top of the backtrace. Use
-      #          when you know how many layers deep in the key call is being
-      #          made.
+      # from - int, from position in array of backtraces
+      # to - int, end position in array of backtraces, can be negative to count from the end
       #
       # Returns a string with each frame of the backtrace separated by '\r\n'.
       #
-      def backtrace(ignore = 0)
+      def backtrace(from = 0, to = -1)
         bt = Kernel.caller
-        bt.slice!(0, ignore)
+        bt = bt[from..to]
         trim_backtrace(bt).join("\r\n")
       end
 

--- a/lib/appoptics_apm/api/util.rb
+++ b/lib/appoptics_apm/api/util.rb
@@ -31,8 +31,7 @@ module AppOpticsAPM
       #
       def backtrace(from = 0, to = -1)
         bt = Kernel.caller
-        bt = bt[from..to]
-        trim_backtrace(bt).join("\r\n")
+        trim_backtrace(bt[from..to]).join("\r\n")
       end
 
       # Internal: Trim a backtrace to a manageable size
@@ -114,7 +113,7 @@ module AppOpticsAPM
       end
 
       def xtrace_v2?(xtr)
-        return xtr && xtr.start_with?('2B')
+        xtr && xtr.start_with?('2B')
       end
     end
   end

--- a/lib/appoptics_apm/frameworks/grape.rb
+++ b/lib/appoptics_apm/frameworks/grape.rb
@@ -53,7 +53,8 @@ module AppOpticsAPM
         end
 
         def error_response_with_appoptics(error = {})
-          status, headers, body = error_response_without_appoptics(error)
+          response = error_response_without_appoptics(error)
+          status, headers, _body = response.finish
 
           xtrace = AppOpticsAPM::Context.toString
 
@@ -77,7 +78,7 @@ module AppOpticsAPM
             end
           end
 
-          [status, headers, body]
+          response
         end
       end
     end

--- a/lib/appoptics_apm/frameworks/padrino.rb
+++ b/lib/appoptics_apm/frameworks/padrino.rb
@@ -58,7 +58,7 @@ module AppOpticsAPM
   end
 end
 
-if defined?(Padrino) && AppopticsAPM::Config[:padrino][:enabled]
+if defined?(Padrino) && AppOpticsAPM::Config[:padrino][:enabled]
   # This instrumentation is a superset of the Sinatra instrumentation similar
   # to how Padrino is a superset of Sinatra itself.
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting Padrino' if AppOpticsAPM::Config[:verbose]

--- a/lib/appoptics_apm/frameworks/sinatra.rb
+++ b/lib/appoptics_apm/frameworks/sinatra.rb
@@ -73,7 +73,7 @@ module AppOpticsAPM
   end
 end
 
-if defined?(Sinatra) && AppopticsAPM::Config[:sinatra][:enabled]
+if defined?(Sinatra) && AppOpticsAPM::Config[:sinatra][:enabled]
   require 'appoptics_apm/inst/rack'
 
   AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting Sinatra' if AppOpticsAPM::Config[:verbose]

--- a/lib/appoptics_apm/inst/graphql.rb
+++ b/lib/appoptics_apm/inst/graphql.rb
@@ -60,7 +60,7 @@ if defined?(GraphQL::Tracing)
             kvs = metadata(data, layer)
             kvs[:Key] = platform_key if (PREP_KEYS + EXEC_KEYS).include?(platform_key)
 
-            maybe_set_transaction_name(kvs[:InboundQuery]) if kvs[:InboundQuery] && layer == 'graphql.execute'
+            transaction_name(kvs[:InboundQuery]) if kvs[:InboundQuery] && layer == 'graphql.execute'
 
             ::AppOpticsAPM::SDK.trace(layer, kvs) do
               kvs.clear # we don't have to send them twice
@@ -78,7 +78,7 @@ if defined?(GraphQL::Tracing)
             ::AppOpticsAPM::Config[:graphql] ||= {}
           end
 
-          def maybe_set_transaction_name(query)
+          def transaction_name(query)
             return if gql_config[:transaction_name] == false ||
                       ::AppOpticsAPM::SDK.get_transaction_name
 

--- a/lib/appoptics_apm/inst/graphql.rb
+++ b/lib/appoptics_apm/inst/graphql.rb
@@ -12,6 +12,7 @@
 # TODO: make sure this stays up to date with
 # ____  what is in the graphql gem and vice-versa
 
+
 if defined?(GraphQL::Tracing)
   module GraphQL
     module Tracing
@@ -162,6 +163,8 @@ if defined?(GraphQL::Tracing)
           end
 
           def sanitize(query)
+            return unless query
+
             # remove arguments
             query.gsub(/"[^"]*"/, '"?"')                 # strings
                  .gsub(/-?[0-9]*\.?[0-9]+e?[0-9]*/, '?') # ints + floats
@@ -169,6 +172,8 @@ if defined?(GraphQL::Tracing)
           end
 
           def remove_comments(query)
+            return unless query
+
             query.gsub(/#[^\n\r]*/, '')
           end
         end

--- a/lib/appoptics_apm/inst/graphql.rb
+++ b/lib/appoptics_apm/inst/graphql.rb
@@ -21,7 +21,7 @@ if defined?(GraphQL::Tracing)
       this_version = Gem::Version.new('1.0.0')
 
       if defined?(GraphQL::Tracing::AppOpticsTracing)
-        if this_version > GraphQL::Tracing::AppOpticsTracing::VERSION
+        if this_version > GraphQL::Tracing::AppOpticsTracing.version
           send(:remove_const, :AppOpticsTracing)
         else
           dont_redefine = true
@@ -40,7 +40,10 @@ if defined?(GraphQL::Tracing)
           # During auto-instrumentation this version of AppOpticsTracing is compared
           # with the version provided in the graphql gem, so that the newer
           # version of the class can be used
-          VERSION = Gem::Version.new('1.0.0').freeze
+
+          def self.version
+            Gem::Version.new('1.0.0')
+          end
 
           self.platform_keys = {
             'lex' => 'lex',

--- a/lib/appoptics_apm/sdk/tracing.rb
+++ b/lib/appoptics_apm/sdk/tracing.rb
@@ -411,7 +411,7 @@ module AppOpticsAPM
       #
       # === Example:
       #
-      #   unless AppopticsAPM::SDK.appoptics_ready?(10_000)
+      #   unless AppOpticsAPM::SDK.appoptics_ready?(10_000)
       #     Logger.info "AppOptics not ready after 10 seconds, no metrics will be sent"
       #   end
       #
@@ -424,7 +424,7 @@ module AppOpticsAPM
         # OBOE_SERVER_RESPONSE_LIMIT_EXCEEDED 3
         # OBOE_SERVER_RESPONSE_INVALID_API_KEY 4
         # OBOE_SERVER_RESPONSE_CONNECT_ERROR 5
-        AppopticsAPM::Context.isReady(wait_milliseconds) == 1
+        AppOpticsAPM::Context.isReady(wait_milliseconds) == 1
       end
     end
 

--- a/lib/appoptics_apm/sdk/tracing.rb
+++ b/lib/appoptics_apm/sdk/tracing.rb
@@ -300,7 +300,7 @@ module AppOpticsAPM
               end
 
               AppOpticsAPM::SDK.trace(span, report_kvs) do
-                report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace(2) if backtrace
+                report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if backtrace
                 send(without_appoptics, *args, &block)
               end
             end
@@ -311,7 +311,7 @@ module AppOpticsAPM
         elsif class_method
           klass.define_singleton_method(with_appoptics) do |*args, &block|
             AppOpticsAPM::SDK.trace(span, report_kvs) do
-              report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace(2) if backtrace
+              report_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if backtrace
               send(without_appoptics, *args, &block)
             end
           end

--- a/test/frameworks/grape_test.rb
+++ b/test/frameworks/grape_test.rb
@@ -14,6 +14,7 @@ if defined?(::Grape)
     end
 
     it "alerts me when a new version of grape is released" do
+      skip
       # TODO: because then the restriction on rack in frameworks.gemfile
       # ____  needs to be removed and also this test
       assert_equal "1.2.4", Grape::VERSION, "remove restriction on rack in frameworks.gemfile"

--- a/test/frameworks/grape_test.rb
+++ b/test/frameworks/grape_test.rb
@@ -13,6 +13,12 @@ if defined?(::Grape)
       clear_all_traces
     end
 
+    it "alerts me when a new version of grape is released" do
+      # TODO: because then the restriction on rack in frameworks.gemfile
+      # ____  needs to be removed and also this test
+      assert_equal "1.2.4", Grape::VERSION, "remove restriction on rack in frameworks.gemfile"
+    end
+
     it "should trace a request to a simple grape stack" do
       @app = GrapeSimple
 

--- a/test/instrumentation/graphql/appoptics_tracing_newer.rb
+++ b/test/instrumentation/graphql/appoptics_tracing_newer.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+
+    # This class uses the AppopticsAPM SDK from the appoptics_apm gem to create
+    # traces for GraphQL.
+    #
+    # There are 4 configurations available. They can be set in the
+    # appoptics_apm config file or in code. Please see:
+    # {https://docs.appoptics.com/kb/apm_tracing/ruby/configure}
+    #
+    #     AppOpticsAPM::Config[:graphql][:enabled] = true|false
+    #     AppOpticsAPM::Config[:graphql][:transaction_name]  = true|false
+    #     AppOpticsAPM::Config[:graphql][:sanitize_query] = true|false
+    #     AppOpticsAPM::Config[:graphql][:remove_comments] = true|false
+    class AppOpticsTracing < GraphQL::Tracing::PlatformTracing
+      # These GraphQL events will show up as 'graphql.prep' spans
+      PREP_KEYS = ['lex', 'parse', 'validate', 'analyze_query', 'analyze_multiplex'].freeze
+      EXEC_KEYS = ['execute_multiplex', 'execute_query', 'execute_query_lazy'].freeze
+
+      # During auto-instrumentation this version of AppOpticsTracing is compared
+      # with the version provided in the graphql gem, so that the newer
+      # version of the class can be used
+      def self.version
+        Gem::Version.new('9.0.0')
+      end
+
+      self.platform_keys = {
+        'lex' => 'lex',
+        'parse' => 'parse',
+        'validate' => 'validate',
+        'analyze_query' => 'analyze_query',
+        'analyze_multiplex' => 'analyze_multiplex',
+        'execute_multiplex' => 'execute_multiplex',
+        'execute_query' => 'execute_query',
+        'execute_query_lazy' => 'execute_query_lazy'
+      }
+
+      def platform_trace(platform_key, _key, data)
+        return yield if !defined?(AppOpticsAPM) || gql_config[:enabled] == false
+
+        layer = span_name(platform_key)
+        kvs = metadata(data, layer)
+        kvs[:Key] = platform_key if (PREP_KEYS + EXEC_KEYS).include?(platform_key)
+
+        transaction_name(kvs[:InboundQuery]) if kvs[:InboundQuery] && layer == 'graphql.execute'
+
+        ::AppOpticsAPM::SDK.trace(layer, kvs) do
+          kvs.clear # we don't have to send them twice
+          yield
+        end
+      end
+
+      def platform_field_key(type, field)
+        "graphql.#{type.name}.#{field.name}"
+      end
+
+      private
+
+      def gql_config
+        ::AppOpticsAPM::Config[:graphql] ||= {}
+      end
+
+      def transaction_name(query)
+        return if gql_config[:transaction_name] == false ||
+          ::AppOpticsAPM::SDK.get_transaction_name
+
+        split_query = query.strip.split(/\W+/, 3)
+        split_query[0] = 'query' if split_query[0].empty?
+        name = "graphql.#{split_query[0..1].join('.')}"
+
+        ::AppOpticsAPM::SDK.set_transaction_name(name)
+      end
+
+      def multiplex_transaction_name(names)
+        return if gql_config[:transaction_name] == false ||
+          ::AppOpticsAPM::SDK.get_transaction_name
+
+        name = "graphql.multiplex.#{names.join('.')}"
+        name = "#{name[0..251]}..." if name.length > 254
+
+        ::AppOpticsAPM::SDK.set_transaction_name(name)
+      end
+
+      def span_name(key)
+        return 'graphql.prep' if PREP_KEYS.include?(key)
+        return 'graphql.execute' if EXEC_KEYS.include?(key)
+
+        key[/^graphql\./] ? key : "graphql.#{key}"
+      end
+
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def metadata(data, layer)
+        data.keys.map do |key|
+          case key
+          when :context
+            graphql_context(data[key], layer)
+          when :query
+            graphql_query(data[key])
+          when :query_string
+            graphql_query_string(data[key])
+          when :multiplex
+            graphql_multiplex(data[key])
+          else
+            [key, data[key]]
+          end
+        end.flatten.each_slice(2).to_h.merge(Spec: 'graphql')
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+      def graphql_context(context, layer)
+        context.errors && context.errors.each do |err|
+          AppOpticsAPM::API.log_exception(layer, err)
+        end
+
+        [[:Path, context.path.join('.')]]
+      end
+
+      def graphql_query(query)
+        return [] unless query
+
+        query_string = query.query_string
+        query_string = remove_comments(query_string) if gql_config[:remove_comments] != false
+        query_string = sanitize(query_string) if gql_config[:sanitize_query] != false
+
+        [[:InboundQuery, query_string],
+         [:Operation, query.selected_operation_name]]
+      end
+
+      def graphql_query_string(query_string)
+        query_string = remove_comments(query_string) if gql_config[:remove_comments] != false
+        query_string = sanitize(query_string) if gql_config[:sanitize_query] != false
+
+        [:InboundQuery, query_string]
+      end
+
+      def graphql_multiplex(data)
+        names = data.queries.map(&:operations).map(&:keys).flatten.compact
+        multiplex_transaction_name(names) if names.size > 1
+
+        [:Operations, names.join(', ')]
+      end
+
+      def sanitize(query)
+        # remove arguments
+        query.gsub(/"[^"]*"/, '"?"')                 # strings
+          .gsub(/-?[0-9]*\.?[0-9]+e?[0-9]*/, '?') # ints + floats
+          .gsub(/\[[^\]]*\]/, '[?]')              # arrays
+      end
+
+      def remove_comments(query)
+        query.gsub(/#[^\n\r]*/, '')
+      end
+    end
+  end
+end

--- a/test/instrumentation/graphql/appoptics_tracing_older.rb
+++ b/test/instrumentation/graphql/appoptics_tracing_older.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+
+    # This class uses the AppopticsAPM SDK from the appoptics_apm gem to create
+    # traces for GraphQL.
+    #
+    # There are 4 configurations available. They can be set in the
+    # appoptics_apm config file or in code. Please see:
+    # {https://docs.appoptics.com/kb/apm_tracing/ruby/configure}
+    #
+    #     AppOpticsAPM::Config[:graphql][:enabled] = true|false
+    #     AppOpticsAPM::Config[:graphql][:transaction_name]  = true|false
+    #     AppOpticsAPM::Config[:graphql][:sanitize_query] = true|false
+    #     AppOpticsAPM::Config[:graphql][:remove_comments] = true|false
+    class AppOpticsTracing < GraphQL::Tracing::PlatformTracing
+      # These GraphQL events will show up as 'graphql.prep' spans
+      PREP_KEYS = ['lex', 'parse', 'validate', 'analyze_query', 'analyze_multiplex'].freeze
+      EXEC_KEYS = ['execute_multiplex', 'execute_query', 'execute_query_lazy'].freeze
+
+      # During auto-instrumentation this version of AppOpticsTracing is compared
+      # with the version provided in the graphql gem, so that the newer
+      # version of the class can be used
+      def self.version
+        Gem::Version.new('0.0.1')
+      end
+
+      self.platform_keys = {
+        'lex' => 'lex',
+        'parse' => 'parse',
+        'validate' => 'validate',
+        'analyze_query' => 'analyze_query',
+        'analyze_multiplex' => 'analyze_multiplex',
+        'execute_multiplex' => 'execute_multiplex',
+        'execute_query' => 'execute_query',
+        'execute_query_lazy' => 'execute_query_lazy'
+      }
+
+      def platform_trace(platform_key, _key, data)
+        return yield if !defined?(AppOpticsAPM) || gql_config[:enabled] == false
+
+        layer = span_name(platform_key)
+        kvs = metadata(data, layer)
+        kvs[:Key] = platform_key if (PREP_KEYS + EXEC_KEYS).include?(platform_key)
+
+        transaction_name(kvs[:InboundQuery]) if kvs[:InboundQuery] && layer == 'graphql.execute'
+
+        ::AppOpticsAPM::SDK.trace(layer, kvs) do
+          kvs.clear # we don't have to send them twice
+          yield
+        end
+      end
+
+      def platform_field_key(type, field)
+        "graphql.#{type.name}.#{field.name}"
+      end
+
+      private
+
+      def gql_config
+        ::AppOpticsAPM::Config[:graphql] ||= {}
+      end
+
+      def transaction_name(query)
+        return if gql_config[:transaction_name] == false ||
+          ::AppOpticsAPM::SDK.get_transaction_name
+
+        split_query = query.strip.split(/\W+/, 3)
+        split_query[0] = 'query' if split_query[0].empty?
+        name = "graphql.#{split_query[0..1].join('.')}"
+
+        ::AppOpticsAPM::SDK.set_transaction_name(name)
+      end
+
+      def multiplex_transaction_name(names)
+        return if gql_config[:transaction_name] == false ||
+          ::AppOpticsAPM::SDK.get_transaction_name
+
+        name = "graphql.multiplex.#{names.join('.')}"
+        name = "#{name[0..251]}..." if name.length > 254
+
+        ::AppOpticsAPM::SDK.set_transaction_name(name)
+      end
+
+      def span_name(key)
+        return 'graphql.prep' if PREP_KEYS.include?(key)
+        return 'graphql.execute' if EXEC_KEYS.include?(key)
+
+        key[/^graphql\./] ? key : "graphql.#{key}"
+      end
+
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def metadata(data, layer)
+        data.keys.map do |key|
+          case key
+          when :context
+            graphql_context(data[key], layer)
+          when :query
+            graphql_query(data[key])
+          when :query_string
+            graphql_query_string(data[key])
+          when :multiplex
+            graphql_multiplex(data[key])
+          else
+            [key, data[key]]
+          end
+        end.flatten.each_slice(2).to_h.merge(Spec: 'graphql')
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+      def graphql_context(context, layer)
+        context.errors && context.errors.each do |err|
+          AppOpticsAPM::API.log_exception(layer, err)
+        end
+
+        [[:Path, context.path.join('.')]]
+      end
+
+      def graphql_query(query)
+        return [] unless query
+
+        query_string = query.query_string
+        query_string = remove_comments(query_string) if gql_config[:remove_comments] != false
+        query_string = sanitize(query_string) if gql_config[:sanitize_query] != false
+
+        [[:InboundQuery, query_string],
+         [:Operation, query.selected_operation_name]]
+      end
+
+      def graphql_query_string(query_string)
+        query_string = remove_comments(query_string) if gql_config[:remove_comments] != false
+        query_string = sanitize(query_string) if gql_config[:sanitize_query] != false
+
+        [:InboundQuery, query_string]
+      end
+
+      def graphql_multiplex(data)
+        names = data.queries.map(&:operations).map(&:keys).flatten.compact
+        multiplex_transaction_name(names) if names.size > 1
+
+        [:Operations, names.join(', ')]
+      end
+
+      def sanitize(query)
+        # remove arguments
+        query.gsub(/"[^"]*"/, '"?"')                 # strings
+          .gsub(/-?[0-9]*\.?[0-9]+e?[0-9]*/, '?') # ints + floats
+          .gsub(/\[[^\]]*\]/, '[?]')              # arrays
+      end
+
+      def remove_comments(query)
+        query.gsub(/#[^\n\r]*/, '')
+      end
+    end
+  end
+end

--- a/test/instrumentation/graphql_test.rb
+++ b/test/instrumentation/graphql_test.rb
@@ -444,27 +444,14 @@ describe GraphQL::Tracing::AppOpticsTracing do
   end
 
   describe 'loading' do
-    let :graphql_appoptics do
-      File.join(Gem.loaded_specs['graphql'].full_gem_path, 'lib/graphql/tracing/appoptics_tracing.rb')
-    end
-
-    before do
-      # it does not make sense but this has to be done before, but otherwise it
-      # gets stuck with the graphql version of GraphQL::Tracing::AppOpticsTracing
-      Kernel.silence_warnings do
-        GraphQL::Tracing::AppOpticsTracing::VERSION = Gem::Version.new('0.0.1')
-        load 'lib/appoptics_apm/inst/graphql.rb'
-      end
-    end
-
+    # in these 2 tests we are simulating the fact that the
+    # GraphQL::Tracing::AppOpticsTracing class
+    # from the graphql gem will be loaded first
     it 'uses the newer version of AppOpticsTracing from the appoptics_apm gem' do
-      skip unless File.exist?(graphql_appoptics)
       Kernel.silence_warnings do # silence warning about re-initializing a const
-        load graphql_appoptics
-        # make the graphql version return an low version number
-        GraphQL::Tracing::AppOpticsTracing::VERSION = Gem::Version.new('0.0.1')
-
+        load 'test/instrumentation/graphql/appoptics_tracing_older.rb'
         load 'lib/appoptics_apm/inst/graphql.rb'
+
         assert_match 'lib/appoptics_apm/inst/graphql.rb',
                      GraphQL::Tracing::AppOpticsTracing.new.method(:metadata).source_location[0]
         assert_match 'lib/appoptics_apm/inst/graphql.rb',
@@ -473,15 +460,13 @@ describe GraphQL::Tracing::AppOpticsTracing do
     end
 
     it 'uses the newer version of AppOpticsTracing from the graphql gem' do
-      skip unless File.exist?(graphql_appoptics)
       Kernel.silence_warnings do # silence warning about re-initializing a const
-        load graphql_appoptics
-        # make the graphql version return an high version number
-        GraphQL::Tracing::AppOpticsTracing::VERSION = Gem::Version.new('999.0.0')
+        load 'test/instrumentation/graphql/appoptics_tracing_newer.rb'
         load 'lib/appoptics_apm/inst/graphql.rb'
-        assert_match 'graphql-ruby/lib/graphql/tracing/appoptics_tracing.rb',
+
+        assert_match 'graphql/appoptics_tracing_newer.rb',
                      GraphQL::Tracing::AppOpticsTracing.new.method(:metadata).source_location[0]
-        assert_match 'graphql-ruby/lib/graphql/tracing/appoptics_tracing.rb',
+        assert_match 'graphql/appoptics_tracing_newer.rb',
                      GraphQL::Tracing::AppOpticsTracing.new.method(:platform_trace).source_location[0]
       end
     end

--- a/test/instrumentation/grpc_test.rb
+++ b/test/instrumentation/grpc_test.rb
@@ -99,14 +99,14 @@ describe 'GRPC' do
     stop_server
   end
 
-  unless ['file', 'udp'].include?(ENV['APPOPTICS_REPORTER']) || AppopticsAPM::SDK.appoptics_ready?(10_000)
+  unless ['file', 'udp'].include?(ENV['APPOPTICS_REPORTER']) || AppOpticsAPM::SDK.appoptics_ready?(10_000)
     puts "aborting!!! Agent not ready after 10 seconds"
     exit false
   end
 
   describe 'UNARY' do
     it 'should collect traces for unary' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         res = @stub.unary(@address_msg)
       end
 
@@ -138,7 +138,7 @@ describe 'GRPC' do
       AppOpticsAPM::Config[:grpc_client][:collect_backtraces] = true
 
       server_with_backtraces do |stub|
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           stub.unary(@address_msg)
         end
 
@@ -152,7 +152,7 @@ describe 'GRPC' do
 
     # Both: Client Application cancelled the request
     it 'should report CANCELLED for unary' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         begin
           @stub.unary_cancel(@null_msg)
         rescue => _
@@ -173,7 +173,7 @@ describe 'GRPC' do
 
     # Both: Deadline expires before server returns status
     it 'should report DEADLINE_EXCEEDED for unary' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         begin
           AppOpticsAPM::SDK.set_transaction_name('unary_deadline_exceeded')
           @stub.unary_long(@address_msg)
@@ -196,7 +196,7 @@ describe 'GRPC' do
     # Client: Some data transmitted (e.g., request metadata written to TCP connection) before connection breaks
     # Server(not tested): Server shutting down
     it 'should report UNAVAILABLE for unary' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         begin
           @unavailable.unary_unknown(@address_msg)
         rescue => _
@@ -216,7 +216,7 @@ describe 'GRPC' do
     # Client: Error parsing returned status
     # Server: Application throws an exception (r something othe th returning a Status code to terminate an RPC)
     it 'should report UNKNOWN for unary' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         begin
           @stub.unary_unknown(@address_msg)
         rescue => _
@@ -237,7 +237,7 @@ describe 'GRPC' do
     # Server: Method not found, compression not supported*, or request cardinality violation (streaming)*
     # * not tested
     it 'should report UNIMPLEMENTED for unary' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         begin
           @stub.unary_unimplemented(@null_msg)
         rescue => _
@@ -259,7 +259,7 @@ describe 'GRPC' do
     # * not tested
     it 'should report INTERNAL for unary' do
       skip # hard to provoke
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         begin
           @secure.unary_2(@null_msg)
         rescue => _
@@ -287,7 +287,7 @@ describe 'GRPC' do
 
   describe 'CLIENT_STREAMING' do
     it 'should collect traces for client_streaming' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         @stub.client_stream([@phone_msg, @phone_msg])
       end
 
@@ -317,7 +317,7 @@ describe 'GRPC' do
       AppOpticsAPM::Config[:grpc_client][:collect_backtraces] = true
 
       server_with_backtraces do |stub|
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           stub.client_stream([@phone_msg, @phone_msg])
         end
 
@@ -337,7 +337,7 @@ describe 'GRPC' do
 
     it 'should report DEADLINE_EXCEEDED for client_streaming' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @no_time.client_stream_long(Array.new(5, @phone_msg))
         end
       rescue => _
@@ -355,7 +355,7 @@ describe 'GRPC' do
 
     it 'should report CANCELLED for client_streaming' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @stub.client_stream_cancel([@null_msg, @null_msg])
         end
       rescue => _
@@ -372,7 +372,7 @@ describe 'GRPC' do
 
     it 'should report UNAVAILABLE for client_streaming' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @unavailable.client_stream([@phone_msg, @phone_msg])
         end
       rescue => _
@@ -389,7 +389,7 @@ describe 'GRPC' do
 
     it 'should report UNKNOWN for client_streaming' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @stub.client_stream_unknown([@address_msg, @address_msg])
         end
       rescue => _
@@ -406,7 +406,7 @@ describe 'GRPC' do
 
     it 'should report UNIMPLEMENTED for client_streaming' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @stub.client_stream_unimplemented([@phone_msg, @phone_msg])
         end
       rescue => _
@@ -430,7 +430,7 @@ describe 'GRPC' do
 
   describe 'SERVER_STREAMING return Enumerator' do
     it 'should collect traces for server_streaming returning enumerator' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         res = @stub.server_stream(Grpctest::AddressId.new(id: 2))
         res.each { |_| }
       end
@@ -461,7 +461,7 @@ describe 'GRPC' do
       AppOpticsAPM::Config[:grpc_client][:collect_backtraces] = true
 
       server_with_backtraces do |stub|
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           res = stub.server_stream(Grpctest::AddressId.new(id: 2))
           res.each { |_| }
         end
@@ -475,7 +475,7 @@ describe 'GRPC' do
     end
 
     it 'should report CANCEL for server_streaming with enumerator' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         res = @stub.server_stream_cancel(@null_msg)
         begin
           res.each { |_| }
@@ -493,7 +493,7 @@ describe 'GRPC' do
     end
 
     it 'should report DEADLINE_EXCEEDED for server_streaming with enumerator' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         begin
           res = @no_time.server_stream_long(@null_msg)
           res.each { |_| }
@@ -512,7 +512,7 @@ describe 'GRPC' do
 
     it 'should report UNAVAILABLE for server_streaming with enumerator' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           res = @unavailable.server_stream(@null_msg)
           res.each { |_| }
         end
@@ -530,7 +530,7 @@ describe 'GRPC' do
 
     it 'should report UNKNOWN for server_streaming with enumerator' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           res = @stub.server_stream_unknown(@address_msg)
           res.each { |_| }
         end
@@ -549,7 +549,7 @@ describe 'GRPC' do
 
     it 'should report UNIMPLEMENTED for server_streaming with enumerator' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           res = @stub.server_stream_unimplemented(@null_msg)
           res.each { |_| }
         end
@@ -575,7 +575,7 @@ describe 'GRPC' do
 
   describe 'SERVER_STREAMING yield' do
     it 'should collect traces for server_streaming using block' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         @stub.server_stream(Grpctest::AddressId.new(id: 2)) { |_| }
       end
 
@@ -605,7 +605,7 @@ describe 'GRPC' do
       AppOpticsAPM::Config[:grpc_client][:collect_backtraces] = true
 
       server_with_backtraces do |stub|
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           stub.server_stream(Grpctest::AddressId.new(id: 2)) { |_| }
         end
 
@@ -619,7 +619,7 @@ describe 'GRPC' do
 
     it 'should report CANCEL for server_streaming using block' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @stub.server_stream_cancel(@null_msg) { |_| }
         end
       rescue => _
@@ -636,7 +636,7 @@ describe 'GRPC' do
 
     it 'should report DEADLINE_EXCEEDED for server_streaming using block' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @no_time.server_stream_long(@null_msg) { |_| }
         end
       rescue => _
@@ -654,7 +654,7 @@ describe 'GRPC' do
 
     it 'should report UNAVAILABLE for server_streaming using block' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           res = @unavailable.server_stream(@null_msg) { |_| }
         end
       rescue => _
@@ -671,7 +671,7 @@ describe 'GRPC' do
 
     it 'should report UNKNOWN for server_streaming using block' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           res = @stub.server_stream_unknown(@address_msg)
           res.each { |_| }
         end
@@ -689,7 +689,7 @@ describe 'GRPC' do
 
     it 'should report UNIMPLEMENTED for server_streaming using block' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           res = @stub.server_stream_unimplemented(@null_msg) { |_| }
         end
       rescue => _
@@ -713,7 +713,7 @@ describe 'GRPC' do
 
   describe 'BIDI_STREAMING return Enumerator' do
     it 'should collect traces for for bidi_streaming with enumerator' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         response = @stub.bidi_stream([@null_msg, @null_msg])
         response.each { |_| }
       end
@@ -744,7 +744,7 @@ describe 'GRPC' do
       AppOpticsAPM::Config[:grpc_client][:collect_backtraces] = true
 
       server_with_backtraces do |stub|
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           response = stub.bidi_stream([@null_msg, @null_msg])
           response.each { |_| }
         end
@@ -759,7 +759,7 @@ describe 'GRPC' do
 
     it 'should report CANCEL for bidi_streaming with enumerator' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           response = @stub.bidi_stream_cancel([@null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg])
           response.each { |_| }
         end
@@ -777,7 +777,7 @@ describe 'GRPC' do
 
     it 'should report DEADLINE_EXCEEDED for bidi_streaming with enumerator' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           response = @no_time.bidi_stream_long([@null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg])
           response.each { |_| }
         end
@@ -795,7 +795,7 @@ describe 'GRPC' do
 
     it 'should report UNAVAILABLE for bidi_streaming with enumerator' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           response = @unavailable.bidi_stream([@null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg])
           response.each { |_| }
         end
@@ -813,7 +813,7 @@ describe 'GRPC' do
 
     it 'should report UNKNOWN for bidi_streaming with enumerator' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           response = @stub.bidi_stream_unknown([@null_msg, @null_msg])
           response.each { |_| }
         end
@@ -831,7 +831,7 @@ describe 'GRPC' do
 
     it 'should report UNIMPLEMENTED for bidi_streaming with enumerator' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           response = @stub.bidi_stream_unimplemented([@null_msg, @null_msg])
           response.each { |_| }
         end
@@ -860,7 +860,7 @@ describe 'GRPC' do
 
   describe 'BIDI_STREAMING yield' do
     it 'should collect traces for bidi_streaming using block' do
-      AppopticsAPM::SDK.start_trace(:test) do
+      AppOpticsAPM::SDK.start_trace(:test) do
         @stub.bidi_stream([@null_msg, @null_msg]) { |_| }
       end
 
@@ -890,7 +890,7 @@ describe 'GRPC' do
       AppOpticsAPM::Config[:grpc_client][:collect_backtraces] = true
 
       server_with_backtraces do |stub|
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           stub.bidi_stream([@phone_msg, @phone_msg]) { |_| }
         end
 
@@ -904,7 +904,7 @@ describe 'GRPC' do
 
     it 'should report CANCEL for bidi_streaming using block' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @stub.bidi_stream_cancel([@null_msg, @null_msg]) { |_| }
         end
       rescue => _
@@ -921,7 +921,7 @@ describe 'GRPC' do
 
     it 'should report DEADLINE_EXCEEDED for bidi_streaming using block' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @no_time.bidi_stream_long([@null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg]) { |_| }
         end
       rescue => _
@@ -938,7 +938,7 @@ describe 'GRPC' do
 
     it 'should report UNAVAILABLE for bidi_streaming using block' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @unavailable.bidi_stream([@null_msg, @null_msg, @null_msg, @null_msg, @null_msg, @null_msg]) { |_| }
         end
       rescue => _
@@ -955,7 +955,7 @@ describe 'GRPC' do
 
     it 'should report UNKNOWN for bidi_streaming using block' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @stub.bidi_stream_unknown([@null_msg, @null_msg]) { |_| }
         end
       rescue => _
@@ -972,7 +972,7 @@ describe 'GRPC' do
 
     it 'should report UNIMPLEMENTED for bidi_streaming using block' do
       begin
-        AppopticsAPM::SDK.start_trace(:test) do
+        AppOpticsAPM::SDK.start_trace(:test) do
           @stub.bidi_stream_unimplemented([@null_msg, @null_msg]) { |_| }
         end
       rescue => _
@@ -1002,7 +1002,7 @@ describe 'GRPC' do
       @count.times do
         threads << Thread.new do
           begin
-            AppopticsAPM::SDK.start_trace(:test) do
+            AppOpticsAPM::SDK.start_trace(:test) do
               @stub.bidi_stream(Array.new(200, @phone_msg)) { |_| }
             end
           rescue => _
@@ -1050,7 +1050,7 @@ describe 'GRPC' do
       @count.times do
         threads << Thread.new do
           begin
-            AppopticsAPM::SDK.start_trace(:test) do
+            AppOpticsAPM::SDK.start_trace(:test) do
               @unavailable.bidi_stream(Array.new(200, @phone_msg)) { |_| }
             end
           rescue => _
@@ -1075,7 +1075,7 @@ describe 'GRPC' do
       (3*@count).times do
         threads << Thread.new do
           begin
-            AppopticsAPM::SDK.start_trace(:test) do
+            AppOpticsAPM::SDK.start_trace(:test) do
               @stub.bidi_stream_varying(Array.new(20, @phone_msg)) { |_| }
             end
           rescue => _

--- a/test/instrumentation/logger_formatter_helper.rb
+++ b/test/instrumentation/logger_formatter_helper.rb
@@ -3,12 +3,12 @@
 describe "include traceId in message " do
 
   before do
-    AppopticsAPM::Context.clear
+    AppOpticsAPM::Context.clear
     @log_traceId = AppOpticsAPM::Config[:log_traceId]
   end
 
   after do
-    AppopticsAPM::Context.clear
+    AppOpticsAPM::Context.clear
     AppOpticsAPM::Config[:log_traceId] = @log_traceId
   end
 

--- a/test/jobs/delayed_job/remote_call_worker_job.rb
+++ b/test/jobs/delayed_job/remote_call_worker_job.rb
@@ -6,13 +6,13 @@ class DJRemoteCallWorkerJob
 
   def self.perform(*args)
     # Make some random Dalli (memcache) calls and top it
-    # off with an excon call to the background rack webserver.
+    # off with an call to the background rack webserver.
     @dc = Dalli::Client.new
     @dc.get(rand(10).to_s)
-    uri = URI('http://gameface.in/gamers')
-    http = Net::HTTP.new(uri.host, uri.port)
-    request = Net::HTTP::Get.new(uri.request_uri)
-    http.request(request)
+
+    uri = URI('http://127.0.0.1:8110')
+    Net::HTTP.get(uri)
+
     @dc.get(rand(10).to_s)
     @dc.get(rand(10).to_s)
     @dc.get_multi([:one, :two, :three, :four, :five, :six])

--- a/test/jobs/delayed_job/remote_call_worker_job.rb
+++ b/test/jobs/delayed_job/remote_call_worker_job.rb
@@ -6,7 +6,7 @@ class DJRemoteCallWorkerJob
 
   def self.perform(*args)
     # Make some random Dalli (memcache) calls and top it
-    # off with an call to the background rack webserver.
+    # off with a call to the background rack webserver.
     @dc = Dalli::Client.new
     @dc.get(rand(10).to_s)
 

--- a/test/jobs/resque/remote_call_worker_job.rb
+++ b/test/jobs/resque/remote_call_worker_job.rb
@@ -6,13 +6,13 @@ class ResqueRemoteCallWorkerJob
 
   def self.perform(*args)
     # Make some random Dalli (memcache) calls and top it
-    # off with an excon call to the background rack webserver.
+    # off with a call to the background rack webserver.
     @dc = Dalli::Client.new
     @dc.get(rand(10).to_s)
-    uri = URI('http://gameface.in/gamers')
-    http = Net::HTTP.new(uri.host, uri.port)
-    request = Net::HTTP::Get.new(uri.request_uri)
-    http.request(request)
+
+    uri = URI('http://127.0.0.1:8110')
+    Net::HTTP.get(uri)
+
     @dc.get(rand(10).to_s)
     @dc.get(rand(10).to_s)
     @dc.get_multi([:one, :two, :three, :four, :five, :six])

--- a/test/jobs/sidekiq/remote_call_worker_job.rb
+++ b/test/jobs/sidekiq/remote_call_worker_job.rb
@@ -6,13 +6,13 @@ class RemoteCallWorkerJob
 
   def perform(*args)
     # Make some random Dalli (memcache) calls and top it
-    # off with an excon call to the background rack webserver.
+    # off with a call to the background rack webserver.
     @dc = Dalli::Client.new
     @dc.get(rand(10).to_s)
-    uri = URI('http://gameface.in/gamers')
-    http = Net::HTTP.new(uri.host, uri.port)
-    request = Net::HTTP::Get.new(uri.request_uri)
-    http.request(request)
+
+    uri = URI('http://127.0.0.1:8110')
+    Net::HTTP.get(uri)
+
     @dc.get(rand(10).to_s)
     @dc.get(rand(10).to_s)
     @dc.get_multi([:one, :two, :three, :four, :five, :six])

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -331,7 +331,7 @@ def print_traces(traces, more_keys = [])
     puts "#{indent}Label:   #{trace["Label"]}"
     puts "#{indent}Layer:   #{trace["Layer"]}"
 
-    more_keys.each { |key| puts "#{indent}#{key}:   #{trace[key]}"}
+    more_keys.each { |key| puts "#{indent}#{key}:   #{trace[key]}" if trace[key] }
 
     indent = indent[0...-2] if trace["Label"] == "exit"
   end

--- a/test/support/transaction_metrics_test.rb
+++ b/test/support/transaction_metrics_test.rb
@@ -21,10 +21,10 @@ describe 'TransactionSettingsTest' do
 
   describe 'metrics' do
     it 'obeys do_metrics false' do
-      AppopticsAPM::TransactionMetrics.expects(:send_metrics).never
-      AppopticsAPM.expects(:transaction_name=).never
+      AppOpticsAPM::TransactionMetrics.expects(:send_metrics).never
+      AppOpticsAPM.expects(:transaction_name=).never
 
-      settings = AppopticsAPM::TransactionSettings.new
+      settings = AppOpticsAPM::TransactionSettings.new
       settings.do_sample = false
       settings.do_metrics = false
 
@@ -35,10 +35,10 @@ describe 'TransactionSettingsTest' do
     end
 
     it 'obeys do_metrics true' do
-      AppopticsAPM::TransactionMetrics.expects(:send_metrics).returns('name')
-      AppopticsAPM.expects(:transaction_name=).with('name')
+      AppOpticsAPM::TransactionMetrics.expects(:send_metrics).returns('name')
+      AppOpticsAPM.expects(:transaction_name=).with('name')
 
-      settings = AppopticsAPM::TransactionSettings.new
+      settings = AppOpticsAPM::TransactionSettings.new
       settings.do_sample = true
       settings.do_metrics = true
 
@@ -49,10 +49,10 @@ describe 'TransactionSettingsTest' do
     end
 
     it 'sends metrics when there is an error' do
-      AppopticsAPM::TransactionMetrics.expects(:send_metrics).returns('name')
-      AppopticsAPM.expects(:transaction_name=).with('name')
+      AppOpticsAPM::TransactionMetrics.expects(:send_metrics).returns('name')
+      AppOpticsAPM.expects(:transaction_name=).with('name')
 
-      settings = AppopticsAPM::TransactionSettings.new
+      settings = AppOpticsAPM::TransactionSettings.new
       settings.do_sample = true
       settings.do_metrics = true
       begin

--- a/test/unit/api_sdk/sdk_test.rb
+++ b/test/unit/api_sdk/sdk_test.rb
@@ -667,17 +667,17 @@ describe AppOpticsAPM::SDK do
 
   describe 'appoptics_ready?' do
     it 'should return true if it can connect' do
-      AppopticsAPM::Context.expects(:isReady).with(10_000).returns(1)
+      AppOpticsAPM::Context.expects(:isReady).with(10_000).returns(1)
       assert AppOpticsAPM::SDK.appoptics_ready?(10_000)
     end
 
     it 'should work with no arg' do
-      AppopticsAPM::Context.expects(:isReady).returns(1)
+      AppOpticsAPM::Context.expects(:isReady).returns(1)
       assert AppOpticsAPM::SDK.appoptics_ready?
     end
 
     it 'should return false if it cannot connect' do
-      AppopticsAPM::Context.expects(:isReady).returns(2)
+      AppOpticsAPM::Context.expects(:isReady).returns(2)
       refute AppOpticsAPM::SDK.appoptics_ready?
     end
   end


### PR DESCRIPTION
- all execute layers are called graphql.execute with a :Key to specify
- only server errors are reported
- errors are reported as error events and not Errors KVs
- multiplex requests have a transaction name like graphql.multiplex.<operations>

- correction to case in AppOpticsAPM in grpc and some other files
- correction to the index args in the AppOpticsAPM.backtrace method

