### PR TITLE
Ao 16502 rack cache

### DIFF
--- a/appoptics_apm.gemspec
+++ b/appoptics_apm.gemspec
@@ -42,7 +42,7 @@ Automatic tracing and metrics for Ruby applications. Get started at appoptics.co
 
   s.extensions = ['ext/oboe_metal/extconf.rb'] unless defined?(JRUBY_VERSION)
 
-  s.add_runtime_dependency('json', '~> 2.3')
+  s.add_runtime_dependency('json')
   s.add_runtime_dependency('no_proxy_fix', '~> 0.1.2', '>= 0.1.2')
 
   # Development dependencies used in gem development & testing

--- a/lib/appoptics_apm/config.rb
+++ b/lib/appoptics_apm/config.rb
@@ -65,17 +65,17 @@ module AppOpticsAPM
       config_file = File.join(Dir.pwd, 'appoptics_apm_config.rb')
       config_files << config_file if File.exist?(config_file)
 
-      return if config_files.empty?  # we use the defaults from the template in this case
-
-      if config_files.size > 1
-        AppOpticsAPM.logger.warn [
-          '[appoptics_apm/config] Multiple configuration files configured, using the first one listed: ',
-          config_files.join(', ')
-        ].join(' ')
+      unless config_files.empty? # we use the defaults from the template if there are no config files
+        if config_files.size > 1
+          AppOpticsAPM.logger.warn [
+                                     '[appoptics_apm/config] Multiple configuration files configured, using the first one listed: ',
+                                     config_files.join(', ')
+                                   ].join(' ')
+        end
+        load(config_files[0])
+        # sets AppOpticsAPM::Config[:debug_level], AppOpticsAPM.logger.level
+        set_log_level
       end
-      load(config_files[0])
-      # sets AppOpticsAPM::Config[:debug_level], AppOpticsAPM.logger.level
-      set_log_level
 
       # the verbose setting is only relevant for ruby, ENV['APPOPTICS_GEM_VERBOSE'] overrides
       if ENV.key?('APPOPTICS_GEM_VERBOSE')

--- a/lib/appoptics_apm/config.rb
+++ b/lib/appoptics_apm/config.rb
@@ -73,9 +73,10 @@ module AppOpticsAPM
                                    ].join(' ')
         end
         load(config_files[0])
-        # sets AppOpticsAPM::Config[:debug_level], AppOpticsAPM.logger.level
-        set_log_level
       end
+
+      # sets AppOpticsAPM::Config[:debug_level], AppOpticsAPM.logger.level
+      set_log_level
 
       # the verbose setting is only relevant for ruby, ENV['APPOPTICS_GEM_VERBOSE'] overrides
       if ENV.key?('APPOPTICS_GEM_VERBOSE')

--- a/lib/appoptics_apm/frameworks/rails.rb
+++ b/lib/appoptics_apm/frameworks/rails.rb
@@ -1,6 +1,8 @@
 # Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
+require_relative '../../../lib/appoptics_apm/inst/logger_formatter'
+
 module AppOpticsAPM
   module Rails
     module Helpers
@@ -75,6 +77,10 @@ if defined?(::Rails)
         AppOpticsAPM::Rails.include_helpers
       end
 
+      initializer 'appoptics_apm.controller', before: 'wicked_pdf.register' do
+        AppOpticsAPM::Rails.load_instrumentation
+      end
+
       initializer 'appoptics_apm.rack' do |app|
         AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting rack' if AppOpticsAPM::Config[:verbose]
         app.config.middleware.insert 0, AppOpticsAPM::Rack
@@ -84,7 +90,7 @@ if defined?(::Rails)
         AppOpticsAPM.logger = ::Rails.logger if ::Rails.logger && !ENV.key?('APPOPTICS_GEM_TEST')
 
         AppOpticsAPM::Inst.load_instrumentation
-        AppOpticsAPM::Rails.load_instrumentation
+        # AppOpticsAPM::Rails.load_instrumentation
 
         # Report __Init after fork when in Heroku
         AppOpticsAPM::API.report_init unless AppOpticsAPM.heroku?

--- a/lib/appoptics_apm/inst/rack_cache.rb
+++ b/lib/appoptics_apm/inst/rack_cache.rb
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 SolarWinds, LLC.
+# All rights reserved.
+
+module AppOpticsAPM
+  module RackCacheContext
+
+    ###
+    # This adds a controller.action like transaction name for
+    # requests directly served from the cache without involving a controller.
+    # The resulting transaction name is `rack-cache.<cache-store>`,
+    # e.g. `rack-cache.memcached`
+    #
+    # It is not a full instrumentation, no span is added.
+    #
+    def call!(env)
+      metastore_type = begin
+        if options['rack-cache.metastore']
+          options['rack-cache.metastore'].match(/^([^\:]*)\:/)[1]
+        end || 'unknown_store'
+      rescue
+        'unknown_store'
+      end
+
+      env['appoptics_apm.action'] = metastore_type
+      env['appoptics_apm.controller'] = 'rack-cache'
+
+      super
+    end
+  end
+end
+
+if AppOpticsAPM::Config[:rack_cache][:transaction_name] && defined?(Rack::Cache::Context)
+  AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting rack_cache' if AppOpticsAPM::Config[:verbose]
+  Rack::Cache::Context.send(:prepend, ::AppOpticsAPM::RackCacheContext)
+end

--- a/lib/appoptics_apm/test.rb
+++ b/lib/appoptics_apm/test.rb
@@ -55,6 +55,7 @@ module AppOpticsAPM
           ENV['DATABASE_URL'] = "postgresql://postgres:#{ENV['TRAVIS_PSQL_PASS']}@127.0.0.1:5432/travis_ci_test"
         elsif ENV.key?('DOCKER_PSQL_PASS')
           ENV['DATABASE_URL'] = "postgresql://docker:#{ENV['DOCKER_PSQL_PASS']}@#{ENV['PSQL_HOST']}:5432/travis_ci_test"
+          # ENV['DATABASE_URL'] = "postgresql://postgres@#{ENV['PSQL_HOST']}:5432/travis_ci_test"
         else
           ENV['DATABASE_URL'] = 'postgresql://postgres@127.0.0.1:5432/travis_ci_test'
         end

--- a/lib/appoptics_apm/version.rb
+++ b/lib/appoptics_apm/version.rb
@@ -7,8 +7,8 @@ module AppOpticsAPM
   # appoptics_apm.gemspec during gem build process
   module Version
     MAJOR = 4 # breaking,
-    MINOR = 11 # feature,
-    PATCH = 2 # fix => BFF
+    MINOR = 12 # feature,
+    PATCH = 0 # fix => BFF
 
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
+++ b/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
@@ -113,25 +113,6 @@ if defined?(AppOpticsAPM::Config)
   AppOpticsAPM::Config[:sanitize_sql_opts]   = Regexp::IGNORECASE
 
   #
-  # GraphQL
-  #
-  # Enable tracing for GraphQL.
-  # (true | false, default: true)
-  AppOpticsAPM::Config[:graphql][:enabled] = true
-  # Replace query arguments with a '?' when sent with a trace.
-  # (true | false, default: true)
-  AppOpticsAPM::Config[:graphql][:sanitize] = true
-  # Remove comments from queries when sent with a trace.
-  # (true | false, default: true)
-  AppOpticsAPM::Config[:graphql][:remove_comments] = true
-  # Create a transaction name by combining
-  # "query" or "mutation" with the first word of the query.
-  # This overwrites the default transaction name, which is a combination of
-  # controller + action and would be the same for all graphql queries.
-  # (true | false, default: true)
-  AppOpticsAPM::Config[:graphql][:transaction_name] = true
-
-  #
   # Do Not Trace - DNT
   #
   # DEPRECATED
@@ -157,6 +138,36 @@ if defined?(AppOpticsAPM::Config)
   #
   AppOpticsAPM::Config[:dnt_regexp] = '\.(jpg|jpeg|gif|png|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|js|flv|swf|otf|eot|ttf|woff|woff2|svg|less)(\?.+){0,1}$'
   AppOpticsAPM::Config[:dnt_opts] = Regexp::IGNORECASE
+
+  #
+  # GraphQL
+  #
+  # Enable tracing for GraphQL.
+  # (true | false, default: true)
+  AppOpticsAPM::Config[:graphql][:enabled] = true
+  # Replace query arguments with a '?' when sent with a trace.
+  # (true | false, default: true)
+  AppOpticsAPM::Config[:graphql][:sanitize] = true
+  # Remove comments from queries when sent with a trace.
+  # (true | false, default: true)
+  AppOpticsAPM::Config[:graphql][:remove_comments] = true
+  # Create a transaction name by combining
+  # "query" or "mutation" with the first word of the query.
+  # This overwrites the default transaction name, which is a combination of
+  # controller + action and would be the same for all graphql queries.
+  # (true | false, default: true)
+  AppOpticsAPM::Config[:graphql][:transaction_name] = true
+
+  #
+  # Rack::Cache
+  #
+  # Create a transaction name like `rack-cache.<cache-store>`,
+  # e.g. `rack-cache.memcached`
+  # This can reduce the number of transaction names, when many requests are
+  # served directly from the cache without hitting a controller action.
+  # When set to `false` the path will be used for the transaction name.
+  #
+  AppOpticsAPM::Config[:rack_cache] = { transaction_name: true }
 
   #
   # Transaction Settings

--- a/test/frameworks/apps/sinatra_simple.rb
+++ b/test/frameworks/apps/sinatra_simple.rb
@@ -2,6 +2,13 @@
 # All rights reserved.
 
 require 'sinatra'
+require "rack/cache"
+require "dalli"
+require 'appoptics_apm'
+
+use Rack::Cache,
+    metastore:   'memcached://localhost:11211',
+    entitystore: 'memcached://localhost:11211'
 
 class SinatraSimple < Sinatra::Base
   set :reload, true
@@ -17,6 +24,11 @@ class SinatraSimple < Sinatra::Base
     <%= yield %>
   </body>
 </html>}
+  end
+
+  get "/cache" do
+    cache_control :public, :max_age => 10
+    render :erb, "<h1>I have a header</h1>"
   end
 
   get "/" do

--- a/test/frameworks/rails_shared_tests.rb
+++ b/test/frameworks/rails_shared_tests.rb
@@ -17,6 +17,10 @@ describe "RailsSharedTests" do
     AppOpticsAPM.config_lock.synchronize {
       @tm = AppOpticsAPM::Config[:tracing_mode]
       @sample_rate = AppOpticsAPM::Config[:sample_rate]
+      @dnt_regexp = AppOpticsAPM::Config[:dnt_regexp]
+      @ac_bt = AppOpticsAPM::Config[:action_controller][:collect_backtraces]
+      @av_bt = AppOpticsAPM::Config[:action_view][:collect_backtraces]
+      @rack_bt = AppOpticsAPM::Config[:rack][:collect_backtraces]
     }
   end
 
@@ -24,6 +28,10 @@ describe "RailsSharedTests" do
     AppOpticsAPM.config_lock.synchronize {
       AppOpticsAPM::Config[:tracing_mode] = @tm
       AppOpticsAPM::Config[:sample_rate] = @sample_rate
+      AppOpticsAPM::Config[:dnt_regexp] = @dnt_regexp
+      AppOpticsAPM::Config[:action_controller][:collect_backtraces] = @ac_bt
+      AppOpticsAPM::Config[:action_view][:collect_backtraces] = @av_bt
+      AppOpticsAPM::Config[:rack][:collect_backtraces] = @rack_bt
     }
   end
 
@@ -181,6 +189,51 @@ describe "RailsSharedTests" do
     assert sidekiq_traces.find { |tr| tr['Layer'] == 'sidekiq-worker' && tr['JobName'] == 'ActiveJobWorkerJob' }
     assert sidekiq_traces.find { |tr| tr['Layer'] == 'sidekiq-worker' && tr['Action'] == 'ActiveJobWorkerJob' }
 
+  end
+
+  ### wicked_pdf gem ###########################################################
+  # we don't instrument wicked_pdf, but its instrumentation can
+  # interfere with our instrumentation
+
+  it "finds a 'wicked_pdf.register' initializer" do
+    found = Rails.application.initializers.any? do |initializer|
+      initializer.name == 'wicked_pdf.register'
+    end
+
+    assert found, "'wicked_pdf.register' initializer not found, maybe it changed name"
+  end
+
+  it "traces html from the 'wicked' controller" do
+    AppOpticsAPM::Config[:action_controller][:collect_backtraces] = false
+    AppOpticsAPM::Config[:action_view][:collect_backtraces] = false
+    AppOpticsAPM::Config[:rack][:collect_backtraces] = false
+    uri = URI.parse('http://127.0.0.1:8140/wicked')
+    r = Net::HTTP.get_response(uri)
+
+    traces = get_all_traces
+
+    assert_equal 6, traces.count
+    valid_edges?(traces)
+    assert_equal 2, traces.select { |tr| tr['Layer'] =~ /actionview/ }.count
+  end
+
+  it "traces pdfs from the 'wicked' controller" do
+    # fyi: wicked_pdf is not instrumented
+    AppOpticsAPM::Config[:dnt_regexp] = ''
+    AppOpticsAPM::Config[:action_controller][:collect_backtraces] = false
+    AppOpticsAPM::Config[:action_view][:collect_backtraces] = false
+    AppOpticsAPM::Config[:rack][:collect_backtraces] = false
+
+    uri = URI.parse('http://127.0.0.1:8140/wicked.pdf')
+    r = Net::HTTP.get_response(uri)
+
+    traces = get_all_traces
+
+    assert_equal 6, traces.count
+    valid_edges?(traces)
+
+    traces.select { |tr| tr['Layer'] =~ /sidekiq/ }
+    assert_equal 2, traces.select { |tr| tr['Layer'] =~ /actionview/ }.count
   end
 
 end

--- a/test/instrumentation/rack_cache_test.rb
+++ b/test/instrumentation/rack_cache_test.rb
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 SolarWinds, LLC.
+# All rights reserved
+
+require "minitest_helper"
+
+require File.expand_path(File.dirname(File.dirname(__FILE__)) + '/frameworks/apps/sinatra_simple')
+
+describe Rack::Cache do
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  before do
+    clear_all_traces
+  end
+
+  it 'creates a rack cache transaction name' do
+    get "/cache"
+    get "/cache"
+
+    traces = get_all_traces
+
+    assert_equal 'rack-cache.memcached', traces.last['TransactionName']
+  end
+end

--- a/test/run_tests/Dockerfile_alpine
+++ b/test/run_tests/Dockerfile_alpine
@@ -31,6 +31,7 @@ RUN apk add --upgrade \
       readline-dev \
       ruby-google-protobuf \
       swig \
+      tmux \
       tree \
       vim \
       zlib-dev \

--- a/test/run_tests/Dockerfile_centos
+++ b/test/run_tests/Dockerfile_centos
@@ -31,6 +31,7 @@ RUN yum update -y \
        psmisc \
        readline-devel \
        tcl \
+       tmux \
        tree \
        vim \
        zlib-devel \

--- a/test/run_tests/Dockerfile_debian
+++ b/test/run_tests/Dockerfile_debian
@@ -23,12 +23,14 @@ RUN apt-get update \
        libpcre3-dev \
        libreadline-dev \
        libsasl2-dev \
+       libsqlite3-dev \
        libssl-dev \
 #       openjdk-8-jdk \ # TODO do we need this?
        psmisc \
        vim \
        less \
        tcl \
+       tmux \
        tree \
        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/test/run_tests/Dockerfile_ubuntu
+++ b/test/run_tests/Dockerfile_ubuntu
@@ -22,12 +22,14 @@ RUN apt-get update \
        libpcre3-dev \
        libreadline-dev \
        libsasl2-dev \
+       libsqlite3-dev \
        libssl-dev \
        openjdk-8-jdk \
        psmisc \
        vim \
        less \
        tcl \
+       tmux \
        tree \
        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -100,7 +102,6 @@ RUN apt-get update && \
 
 ENV PATH="/root/.rbenv/bin:/root/.rbenv/shims:$PATH"
 ENV RUBY_ENV=test
-ENV DOCKER_PSQL_PASS=docker
 ENV APPOPTICS_TOKEN_BUCKET_CAPACITY=10000
 ENV APPOPTICS_TOKEN_BUCKET_RATE=10000
 

--- a/test/run_tests/docker-compose.yml
+++ b/test/run_tests/docker-compose.yml
@@ -10,6 +10,7 @@ version: "2.1"
 #
 ########################################################################################################
 x-ao-env: &ao-env
+#  APPOPTICS_COLLECTOR: "collector-stg.appoptics.com"
   APPOPTICS_COLLECTOR: "/tmp/appoptics_traces.bson"
   APPOPTICS_FROM_S3: "true"
   APPOPTICS_GEM_TEST: "true"
@@ -21,12 +22,13 @@ x-ao-env: &ao-env
   APPOPTICS_TOKEN_BUCKET_CAPACITY: 10000
   APPOPTICS_TOKEN_BUCKET_RATE: 10000
 
-  BUNDLE_GEMFILE: "gemfiles/libraries.gemfile"
+#  BUNDLE_GEMFILE: "gemfiles/libraries.gemfile"
   DOCKER_MYSQL_PASS: "admin"
   DOCKER_PSQL_PASS: "docker"
   MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
   MYSQL_ROOT_PASSWORD: "admin"
   MYSQL_HOST: "ao-ruby-mysql"
+  OBOE_VERSION: "10.0.0"
   PSQL_HOST: "ao_ruby_postgres"
   RUBY_ENV: "test"
   TEST_RUNS_TO_FILE: "true"
@@ -44,8 +46,8 @@ x-ao-shared: &ao-shared
       max-size: "100m"
   ports:
     - "3000"
-  volumes:
-    - ../../:/code/ruby-appoptics
+#  volumes:
+#    - ../../:/code/ruby-appoptics
 #    - /dev/null:/sys/fs/cgroup
 #       - ../../../graphql-ruby-clone/:/code/graphql-ruby
 #       - /Users/maiaengeli/workspace/repos/grpc:/grpc_ruby
@@ -115,6 +117,7 @@ services:
     volumes:
       - ../../:/code/ruby-appoptics
       - ./.ruby_version_centos:/code/ruby-appoptics/.ruby-version
+      - ../../../../repos/rack-cache/:/rack-cache
     environment:
       << : *ao-env
       APPOPTICS_HOSTNAME_ALIAS: "AO_RUBY_CENTOS"
@@ -138,10 +141,10 @@ services:
   ao_ruby_postgres:
     container_name: ao_ruby_postgres
     image: postgres:latest
+    environment:
+      DOCKER_PSQL_PASS: "docker"
     volumes:
       - ./postgres_init.sh:/docker-entrypoint-initdb.d/init-user-db.sh
-#    environment:
-#      POSTGRES_PASSWORD: postgres  # this is the default
 
   ao_ruby_wait:
     container_name: ao_ruby_wait

--- a/test/run_tests/smoke_test/README.md
+++ b/test/run_tests/smoke_test/README.md
@@ -7,9 +7,19 @@ Quickly smoke test the appoptics_apm gem uploaded to package cloud. There should
 - a WARN message with a trace-id
 
 ### how to...
+
 The gem version needs to be updated in the Gemfile.
 
 Use linux containers from parent directory
 
-Inside a container run the script `./smoketest.sh` locally
-or call it from any directory: `bundle exec rake smoke`
+Inside a container run:  `./smoketest.sh` 
+
+```
+mkdir /smoke
+cp -r test/run_tests/smoke_test/* /smoke/.
+cd /smoke
+rm -f Gemfile.lock
+./smoketest.sh
+cd -
+/bin/rm -r /smoke
+```

--- a/test/run_tests/smoke_test/smoketest.sh
+++ b/test/run_tests/smoke_test/smoketest.sh
@@ -4,10 +4,11 @@ path=$(dirname "$0")
 
 export APPOPTICS_COLLECTOR=collector-stg.appoptics.com
 unset APPOPTICS_REPORTER
+unset APPOPTICS_FROM_S3
 
 # bundler has a problem resolving the gem in packagecloud
 # when defining the gemfile via BUNDLE_GEMFILE
-#export BUNDLE_GEMFILE=$path/Gemfile
+# export BUNDLE_GEMFILE=$path/Gemfile
 
 rm -f $path/GemFile.lock
 bundle update --gemfile=$path/Gemfile

--- a/test/servers/app/views/test.html
+++ b/test/servers/app/views/test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Page Title</title>
+</head>
+<body>
+
+<h1>This is a Heading</h1>
+<p>This is a paragraph.</p>
+
+</body>
+</html>

--- a/test/servers/app/views/wicked/show.html.erb
+++ b/test/servers/app/views/wicked/show.html.erb
@@ -1,0 +1,1 @@
+<h1>I a header</h1>

--- a/test/servers/rails4x_8140.rb
+++ b/test/servers/rails4x_8140.rb
@@ -49,6 +49,8 @@ class Rails40MetalStack < Rails::Application
     get "/hello/db"          => "hello#db"
     get "/hello/servererror" => "hello#servererror"
 
+    get "/wicked"   => "wicked#show"
+
     get "/widgets"          => "widgets#all"
     get "/widgets/delete_all" => "widgets#delete_all"
     resources :widgets
@@ -95,6 +97,17 @@ class HelloController < ApplicationController
 
   def servererror
     render :plain => "broken", :status => 500
+  end
+end
+
+class WickedController < ApplicationController
+  def show
+    respond_to do |format|
+      format.html
+      format.pdf do
+        render pdf: "file_name", file: 'test.html'
+      end
+    end
   end
 end
 

--- a/test/servers/rails5x_8140.rb
+++ b/test/servers/rails5x_8140.rb
@@ -48,6 +48,8 @@ class Rails50MetalStack < Rails::Application
     get "/hello/error"       => "hello#error"
     get "/hello/servererror" => "hello#servererror"
 
+    get "/wicked"   => "wicked#show"
+
     get "/widgets"          => "widgets#all"
     get "/widgets/delete_all" => "widgets#delete_all"
     post "/widgets"          => "widgets#create"
@@ -102,6 +104,17 @@ class HelloController < ApplicationController
 
   def servererror
     render :plain => "broken", :status => 500
+  end
+end
+
+class WickedController < ApplicationController
+  def show
+    respond_to do |format|
+      format.html
+      format.pdf do
+        render pdf: "file_name", file: 'test.html'
+      end
+    end
   end
 end
 

--- a/test/servers/rails5x_api_8150.rb
+++ b/test/servers/rails5x_api_8150.rb
@@ -52,7 +52,7 @@ module Rails50APIStack
     config.middleware.delete ActionDispatch::Flash
     config.secret_token = "48837489qkuweoiuoqwehisuakshdjksadhaisdy78o34y138974xyqp9rmye8yrpiokeuioqwzyoiuxftoyqiuxrhm3iou1hrzmjk"
     config.secret_key_base = "2049671-96803948"
-    config.active_record.sqlite3 = {} # deal with https://github.com/rails/rails/issues/37048
+    # config.active_record.sqlite3 = {} # deal with https://github.com/rails/rails/issues/37048
   end
 end
 

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -190,6 +190,12 @@ describe "AppOpticsAPM::Config" do
     _(AppOpticsAPM::Config[:dnt_compiled].inspect).must_equal '/\\.(jpg|jpeg|gif|png|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|js|flv|swf|otf|eot|ttf|woff|woff2|svg|less)(\\?.+){0,1}$/i'
     _(AppOpticsAPM::Config[:dnt_opts]).must_equal Regexp::IGNORECASE
 
+    _(AppOpticsAPM::Config[:graphql][:sanitize]).must_equal true
+    _(AppOpticsAPM::Config[:graphql][:remove_comments]).must_equal true
+    _(AppOpticsAPM::Config[:graphql][:transaction_name]).must_equal true
+
+    _(AppOpticsAPM::Config[:rack_cache][:transaction_name]).must_equal true
+
     _(AppOpticsAPM::Config[:transaction_settings].is_a?(Hash)).must_equal true
     _(AppOpticsAPM::Config[:transaction_settings]).must_equal({ url: [] })
 
@@ -206,7 +212,7 @@ describe "AppOpticsAPM::Config" do
 
     # ... and make sure they are enabled by default
     instrumentation.each do |key|
-      _(AppOpticsAPM::Config[key][:enabled]).must_equal true
+      _(AppOpticsAPM::Config[key][:enabled]).must_equal true, key
     end
 
     _(AppOpticsAPM::Config[:bunnyconsumer][:log_args]).must_equal true


### PR DESCRIPTION
Goal: Have rack_cache report a common transaction name for all invocations instead of the path to reduce the number of different transactions, which can result in the transaction table not loading. No span needed for rack_cache.

This was supposed to be a small PR with an instrumentation and one test for rack_cache.
Sorry, somehow some changes from the last PR are in here again.

The files to focus on are:
`rack_cache.rb` and `rack_cache_test.rb` (and the `sinatra_simple.rb` server for the test)
There is a change in `appoptics_apm_initializer.rb`, `config.rb`, and `config_test.rb`

