### PR TITLE
Remove outdated comment

### DIFF
--- a/lib/appoptics_apm/noop/context.rb
+++ b/lib/appoptics_apm/noop/context.rb
@@ -10,8 +10,6 @@ module AppOpticsAPM
     # noop version of :toString
     # toString would return the current context (xtrace) as string
     #
-    # the noop version returns an empty string
-    #
     def self.toString
       '2B0000000000000000000000000000000000000000000000000000000000'
     end


### PR DESCRIPTION
## Context
The `AppOpticsAPM::Context::toString` method was updated in https://github.com/appoptics/appoptics-apm-ruby/commit/e3bbe8cd63cc418e450db0a2c1fc4b764b635419, making the noop version to return a non-empty string.

## Changes
This PR updates the comment to reflect that change, removing the line that says `the noop version returns an empty string` (which is not true anymore).