### PR TITLE
Ao 17402 current trace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ before_script:
 #  - export APPOPTICS_TOKEN_BUCKET_CAPACITY=1000
 #  - export APPOPTICS_TOKEN_BUCKET_RATE=1000
   - export APPOPTICS_FROM_S3=true
+  - export OBOE_VERSION=10.0.0
 
 #  - bundle update --jobs=3 --retry=3
   - ./.travis/bundle.sh

--- a/lib/appoptics_apm/sdk/current_trace.rb
+++ b/lib/appoptics_apm/sdk/current_trace.rb
@@ -37,14 +37,10 @@ module AppOpticsAPM
         attr_reader :id
 
         def initialize
-          if AppOpticsAPM::Config[:log_traceId] == :never
-            @id = '0000000000000000000000000000000000000000-0'
-          else
-            @xtrace = AppOpticsAPM::Context.toString
-            task_id = AppOpticsAPM::XTrace.task_id(@xtrace)
-            sampled = AppOpticsAPM::XTrace.sampled?(@xtrace)
-            @id = "#{task_id}-#{sampled ? 1 : 0}"
-          end
+          @xtrace = AppOpticsAPM::Context.toString
+          task_id = AppOpticsAPM::XTrace.task_id(@xtrace)
+          sampled = AppOpticsAPM::XTrace.sampled?(@xtrace)
+          @id = "#{task_id}-#{sampled ? 1 : 0}"
         end
 
         # for_log returns a string in the format 'traceId=<current_trace.id>' or ''.

--- a/lib/appoptics_apm/test.rb
+++ b/lib/appoptics_apm/test.rb
@@ -53,8 +53,8 @@ module AppOpticsAPM
       def set_postgresql_env
         if ENV.key?('TRAVIS_PSQL_PASS')
           ENV['DATABASE_URL'] = "postgresql://postgres:#{ENV['TRAVIS_PSQL_PASS']}@127.0.0.1:5432/travis_ci_test"
-        elsif ENV.key?('DOCKER_PSQL_PASS')
-          ENV['DATABASE_URL'] = "postgresql://docker:#{ENV['DOCKER_PSQL_PASS']}@#{ENV['PSQL_HOST']}:5432/travis_ci_test"
+        elsif ENV.key?('POSTGRES_USER')
+          ENV['DATABASE_URL'] = "postgresql://#{ENV['POSTGRES_USER']}@#{ENV['PSQL_HOST']}:5432/travis_ci_test"
           # ENV['DATABASE_URL'] = "postgresql://postgres@#{ENV['PSQL_HOST']}:5432/travis_ci_test"
         else
           ENV['DATABASE_URL'] = 'postgresql://postgres@127.0.0.1:5432/travis_ci_test'

--- a/test/run_tests/docker-compose.yml
+++ b/test/run_tests/docker-compose.yml
@@ -24,11 +24,12 @@ x-ao-env: &ao-env
 
 #  BUNDLE_GEMFILE: "gemfiles/libraries.gemfile"
   DOCKER_MYSQL_PASS: "admin"
-  DOCKER_PSQL_PASS: "docker"
+#  DOCKER_PSQL_PASS: "docker"
   MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
   MYSQL_ROOT_PASSWORD: "admin"
   MYSQL_HOST: "ao-ruby-mysql"
   OBOE_VERSION: "10.0.0"
+  POSTGRES_USER: "docker"
   PSQL_HOST: "ao_ruby_postgres"
   RUBY_ENV: "test"
   TEST_RUNS_TO_FILE: "true"
@@ -142,7 +143,8 @@ services:
     container_name: ao_ruby_postgres
     image: postgres:latest
     environment:
-      DOCKER_PSQL_PASS: "docker"
+      POSTGRES_DB: "travis_ci_test"
+      POSTGRES_USER: "docker"
     volumes:
       - ./postgres_init.sh:/docker-entrypoint-initdb.d/init-user-db.sh
 

--- a/test/run_tests/docker-compose.yml
+++ b/test/run_tests/docker-compose.yml
@@ -33,7 +33,7 @@ x-ao-env: &ao-env
   RUBY_ENV: "test"
   TEST_RUNS_TO_FILE: "true"
 #    - SIMPLECOV_COVERAGE=true
-#    - OBOE_HPP_WIP=true
+#    - OBOE_WIP=true
 #    - APPOPTICS_DEBUG_LEVEL=6
 
 x-ao-shared: &ao-shared

--- a/test/unit/api_sdk/sdk_test.rb
+++ b/test/unit/api_sdk/sdk_test.rb
@@ -222,6 +222,7 @@ describe AppOpticsAPM::SDK do
       xtrace = '2B7435A9FE510AE4533414D425DADF4E180D2B4E3649E60702469DB05F01'
 
       AppOpticsAPM::API.expects(:send_metrics)
+      sleep 0.1
 
       AppOpticsAPM::SDK.start_trace('test_01', xtrace) { 42 }
     end
@@ -661,6 +662,7 @@ describe AppOpticsAPM::SDK do
 
     it 'should return false if the context is invalid' do
       AppOpticsAPM::Context.fromString('2BB05F01')
+      sleep 0.1
       refute AppOpticsAPM::SDK.tracing?
     end
   end

--- a/test/unit/api_sdk/sdk_test.rb
+++ b/test/unit/api_sdk/sdk_test.rb
@@ -257,7 +257,7 @@ describe AppOpticsAPM::SDK do
       AppOpticsAPM::API.expects(:log_event).with('test_01', :entry, anything, anything)
       AppOpticsAPM::Span.expects(:createSpan).with('custom_name_this_one', nil, 0).returns('domain/custom_name_this_one')
       AppOpticsAPM::API.expects(:log_event).with('test_01', :exit, anything, has_entry(:TransactionName => 'domain/custom_name_this_one'))
-
+      sleep 0.1
       AppOpticsAPM::SDK.start_trace('test_01', nil, :TransactionName => 'custom_name') do
         AppOpticsApm::SDK.set_transaction_name('custom_name_this_one')
       end
@@ -294,7 +294,7 @@ describe AppOpticsAPM::SDK do
   describe 'start_trace nested invocation' do
     it 'should call send_metrics only once' do
       AppOpticsAPM::API.expects(:send_metrics).once
-
+      sleep 0.1
       AppOpticsAPM::SDK.start_trace('test_01') do
         AppOpticsAPM::SDK.start_trace('test_02') { 42 }
       end


### PR DESCRIPTION
main change in file current_trace.rb: remove condition that returns '000000...-0' when the setting for log injection is :never

This is an SDK method, but that behavior has not been documented, so it should be save to remove
I think I introduced it for testing, but it ended up being irrelevant and now we have a customer who wants to get the injectable traceId when :never tracing, to add it to there special logging setup

AO-17402