### PR TITLE
AO-17323 init message & oboe param change

### DIFF
--- a/lib/appoptics_apm/api/metrics.rb
+++ b/lib/appoptics_apm/api/metrics.rb
@@ -22,9 +22,12 @@ module  AppOpticsAPM
         start = Time.now
         yield
       ensure
+        # TODO send_metrics is currently used in grpc, sdk
+        # ____ the error (0,1) would have to be returned from yield
+        error = 0
         duration = (1000 * 1000 * (Time.now - start)).to_i
         transaction_name = determine_transaction_name(span, kvs)
-        kvs[:TransactionName] = AppOpticsAPM::Span.createSpan(transaction_name, nil, duration)
+        kvs[:TransactionName] = AppOpticsAPM::Span.createSpan(transaction_name, nil, duration, error)
         AppOpticsAPM.transaction_name = nil
       end
 

--- a/lib/appoptics_apm/util.rb
+++ b/lib/appoptics_apm/util.rb
@@ -271,12 +271,12 @@ module AppOpticsAPM
           platform_info['Force']                        = true
           platform_info['Ruby.Platform.Version']        = RUBY_PLATFORM
           platform_info['Ruby.Version']                 = RUBY_VERSION
-          platform_info['Ruby.AppOptics.Version']    = AppOpticsAPM::Version::STRING
+          platform_info['Ruby.AppOptics.Version']       = AppOpticsAPM::Version::STRING
 
           clib_version_file = File.join(Gem::Specification.find_by_name('appoptics_apm').gem_dir, 'ext', 'oboe_metal', 'src', 'VERSION')
-          platform_info['Ruby.clib.Version']            = File.read(clib_version_file).chomp
+          platform_info['Ruby.AppOpticsExtension.Version'] = File.read(clib_version_file).chomp
           platform_info['RubyHeroku.AppOpticsAPM.Version'] = AppOpticsAPMHeroku::Version::STRING if defined?(AppOpticsAPMHeroku)
-          platform_info['Ruby.TraceMode.Version']       = AppOpticsAPM::Config[:tracing_mode]
+          platform_info['Ruby.TraceMode.Version']          = AppOpticsAPM::Config[:tracing_mode]
 
           # Collect up the loaded gems
           if defined?(Gem) && Gem.respond_to?(:loaded_specs)

--- a/test/instrumentation/grpc_test.rb
+++ b/test/instrumentation/grpc_test.rb
@@ -279,7 +279,7 @@ if defined? GRPC
       end
 
       it 'sends metrics from the server for unary' do
-        Oboe_metal::Span.expects(:createSpan).with('AddressService.unary', nil, is_a(Integer))
+        Oboe_metal::Span.expects(:createSpan).with('AddressService.unary', nil, is_a(Integer), is_a(Integer))
         @stub.unary(@address_msg)
         sleep 0.5
       end
@@ -422,7 +422,7 @@ if defined? GRPC
       end
 
       it 'sends metrics from the server for client_streaming' do
-        Oboe_metal::Span.expects(:createSpan).with('AddressService.client_stream', nil, is_a(Integer))
+        Oboe_metal::Span.expects(:createSpan).with('AddressService.client_stream', nil, is_a(Integer), is_a(Integer))
         @stub.client_stream([@null_msg, @null_msg])
         sleep 0.5
       end
@@ -566,7 +566,7 @@ if defined? GRPC
       end
 
       it 'sends metrics from the server for server_streaming with enumerator' do
-        Oboe_metal::Span.expects(:createSpan).with('AddressService.server_stream', nil, is_a(Integer))
+        Oboe_metal::Span.expects(:createSpan).with('AddressService.server_stream', nil, is_a(Integer), is_a(Integer))
         res = @stub.server_stream(@null_msg)
         res.each { |_| }
         sleep 0.5
@@ -705,7 +705,7 @@ if defined? GRPC
       end
 
       it 'sends metrics from the server for server_streaming using block' do
-        Oboe_metal::Span.expects(:createSpan).with('AddressService.server_stream', nil, is_a(Integer))
+        Oboe_metal::Span.expects(:createSpan).with('AddressService.server_stream', nil, is_a(Integer), is_a(Integer))
         @stub.server_stream(@null_msg) { |_| }
         sleep 0.5
       end
@@ -851,7 +851,7 @@ if defined? GRPC
       end
 
       it 'sends metrics from the server for bidi_streaming with enumerator' do
-        Oboe_metal::Span.expects(:createSpan).with('AddressService.bidi_stream', nil, is_a(Integer))
+        Oboe_metal::Span.expects(:createSpan).with('AddressService.bidi_stream', nil, is_a(Integer), is_a(Integer))
         response = @stub.bidi_stream([@null_msg, @null_msg])
         response.each { |_| }
         sleep 0.5
@@ -990,7 +990,7 @@ if defined? GRPC
       end
 
       it 'sends metrics from the server for bidi_streaming using block' do
-        Oboe_metal::Span.expects(:createSpan).with('AddressService.bidi_stream', nil, is_a(Integer))
+        Oboe_metal::Span.expects(:createSpan).with('AddressService.bidi_stream', nil, is_a(Integer), is_a(Integer))
         @stub.bidi_stream([@null_msg, @null_msg]) { |_| }
         sleep 0.5
       end

--- a/test/run_tests/run_tests.sh
+++ b/test/run_tests/run_tests.sh
@@ -14,7 +14,7 @@
 ##
 
 export BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS=true
-RUBY=`rbenv local`
+# RUBY=`rbenv local`
 
 ## Read opts
 num=-1

--- a/test/run_tests/run_tests.sh
+++ b/test/run_tests/run_tests.sh
@@ -48,11 +48,14 @@ The values for -r, -g, and -e have to correspond to configurations in the .travi
   esac
 done
 
+# version=`rbenv version`
+# set -- $version
+# RUBY=$1
+
 cp -r /code/ruby-appoptics /code/ruby-appoptics_test
-cd /code/ruby-appoptics_test/test/run_tests
 
 ## Read travis configuration
-cd "$( dirname "$0" )/../.."
+cd /code/ruby-appoptics_test/
 mapfile -t input2 < <(test/run_tests/read_travis_yml.rb .travis.yml)
 current_ruby=""
 

--- a/test/support/init_report_test.rb
+++ b/test/support/init_report_test.rb
@@ -15,6 +15,7 @@ describe 'InitReportTest' do
     _(init_kvs.has_key?("Force")).must_equal true
     _(init_kvs.has_key?("Ruby.AppContainer.Version")).must_equal true
     _(init_kvs["Ruby.AppOptics.Version"]).must_equal AppOpticsAPM::Version::STRING
+    _(init_kvs["Ruby.AppOpticsExtension.Version"]).must_equal File.read(clib_version_file).chomp
     _(init_kvs["Ruby.TraceMode.Version"]).must_equal AppOpticsAPM::Config[:tracing_mode]
   end
 

--- a/test/unit/api_sdk/metrics_test.rb
+++ b/test/unit/api_sdk/metrics_test.rb
@@ -12,7 +12,7 @@ describe AppOpticsAPM::API::Metrics do
 
     it 'should send the correct duration and create a transaction name' do
       Time.stub(:now, Time.at(0)) do
-        AppOpticsAPM::Span.expects(:createSpan).with('custom-test', nil, 0)
+        AppOpticsAPM::Span.expects(:createSpan).with('custom-test', nil, 0, 0)
         AppOpticsAPM::API.send_metrics('test', {}) {}
       end
     end
@@ -27,7 +27,7 @@ describe AppOpticsAPM::API::Metrics do
 
     it 'should override the transaction name from the params for createSpan' do
       Time.stub(:now, Time.at(0)) do
-        AppOpticsAPM::Span.expects(:createSpan).with('this_name', nil, 0)
+        AppOpticsAPM::Span.expects(:createSpan).with('this_name', nil, 0, 0)
 
         AppOpticsAPM::SDK.set_transaction_name('this_name')
         # :TransactionName should not even be in there!!!

--- a/test/unit/api_sdk/sdk_test.rb
+++ b/test/unit/api_sdk/sdk_test.rb
@@ -245,7 +245,7 @@ describe AppOpticsAPM::SDK do
     it 'should use the transaction name from opts' do
       Time.expects(:now).returns(Time.at(0)).twice
       AppOpticsAPM::API.expects(:log_event).with('test_01', :entry, anything, Not(has_entry(:TransactionName => 'domain/this_name')))
-      AppOpticsAPM::Span.expects(:createSpan).with('this_name', nil, 0).returns('domain/this_name')
+      AppOpticsAPM::Span.expects(:createSpan).with('this_name', nil, 0, 0).returns('domain/this_name')
       AppOpticsAPM::API.expects(:log_event).with('test_01', :exit, anything, has_entry(:TransactionName => 'domain/this_name'))
 
       result = AppOpticsAPM::SDK.start_trace('test_01', nil, :TransactionName => 'this_name') { 42 }
@@ -255,7 +255,7 @@ describe AppOpticsAPM::SDK do
     it 'should overwrite the transaction name from opts' do
       Time.expects(:now).returns(Time.at(0)).twice
       AppOpticsAPM::API.expects(:log_event).with('test_01', :entry, anything, anything)
-      AppOpticsAPM::Span.expects(:createSpan).with('custom_name_this_one', nil, 0).returns('domain/custom_name_this_one')
+      AppOpticsAPM::Span.expects(:createSpan).with('custom_name_this_one', nil, 0, 0).returns('domain/custom_name_this_one')
       AppOpticsAPM::API.expects(:log_event).with('test_01', :exit, anything, has_entry(:TransactionName => 'domain/custom_name_this_one'))
       sleep 0.1
       AppOpticsAPM::SDK.start_trace('test_01', nil, :TransactionName => 'custom_name') do
@@ -265,7 +265,7 @@ describe AppOpticsAPM::SDK do
 
     it 'should call createSpan and log_end in case of an exception' do
       Time.expects(:now).returns(Time.at(0)).twice
-      AppOpticsAPM::Span.expects(:createSpan).with('custom-test_01', nil, 0).returns('domain/custom-test_01')
+      AppOpticsAPM::Span.expects(:createSpan).with('custom-test_01', nil, 0, 0).returns('domain/custom-test_01')
       AppOpticsAPM::API.expects(:log_end).with('test_01', has_entry(:TransactionName => 'domain/custom-test_01'), instance_of(Oboe_metal::Event))
       begin
         AppOpticsAPM::SDK.start_trace('test_01') do
@@ -277,7 +277,7 @@ describe AppOpticsAPM::SDK do
 
     it 'should report duration correctly when there is an exception' do
       AppOpticsAPM::API.expects(:log_exception).once
-      AppOpticsAPM::Span.expects(:createSpan).with('custom-test_01', nil, 42000000)
+      AppOpticsAPM::Span.expects(:createSpan).with('custom-test_01', nil, 42000000, 0)
       Time.expects(:now).returns(Time.at(0))
       begin
         AppOpticsAPM::SDK.start_trace('test_01') do
@@ -309,7 +309,7 @@ describe AppOpticsAPM::SDK do
 
     it 'should use the opts from the first call to start_trace for transaction name' do
       Time.expects(:now).returns(Time.at(0)).twice
-      AppOpticsAPM::Span.expects(:createSpan).with('custom_name', nil, 0)
+      AppOpticsAPM::Span.expects(:createSpan).with('custom_name', nil, 0, 0)
 
       AppOpticsAPM::SDK.start_trace('test_01', nil, :TransactionName => 'custom_name') do
         AppOpticsAPM::SDK.start_trace('test_02', nil, :TransactionName => 'custom_name_02') { 42 }
@@ -318,7 +318,7 @@ describe AppOpticsAPM::SDK do
 
     it 'should NOT use the opts from the second call to start_trace for transaction name' do
       Time.expects(:now).returns(Time.at(0)).twice
-      AppOpticsAPM::Span.expects(:createSpan).with('custom-test_01', nil, 0)
+      AppOpticsAPM::Span.expects(:createSpan).with('custom-test_01', nil, 0, 0)
 
       AppOpticsAPM::SDK.start_trace('test_01') do
         AppOpticsAPM::SDK.start_trace('test_02', nil, :TransactionName => 'custom_name_02') { 42 }
@@ -327,8 +327,8 @@ describe AppOpticsAPM::SDK do
 
     it 'should use the last assigned transaction name' do
       Time.expects(:now).returns(Time.at(0)).times(4)
-      AppOpticsAPM::Span.expects(:createSpan).with('actually_this_one', nil, 0)
-      AppOpticsAPM::Span.expects(:createSpan).with('actually_this_one_as_well', nil, 0)
+      AppOpticsAPM::Span.expects(:createSpan).with('actually_this_one', nil, 0, 0)
+      AppOpticsAPM::Span.expects(:createSpan).with('actually_this_one_as_well', nil, 0, 0)
 
       AppOpticsAPM::SDK.start_trace('test_01', nil, :TransactionName => 'custom_name') do
         AppOpticsAPM::SDK.set_transaction_name('this_one')
@@ -687,10 +687,10 @@ describe AppOpticsAPM::SDK do
   describe 'createSpan' do
     # Let's test the return value of createSpan a bit too
     it 'should return a transaction name' do
-      assert_equal 'my_name', AppOpticsAPM::Span.createSpan('my_name', nil, 0)
-      assert_equal 'unknown', AppOpticsAPM::Span.createSpan(nil, nil, 0)
-      assert_equal 'unknown', AppOpticsAPM::Span.createSpan('', nil, 0)
-      assert_equal 'domain/my_name', AppOpticsAPM::Span.createSpan('my_name', 'domain', 0)
+      assert_equal 'my_name', AppOpticsAPM::Span.createSpan('my_name', nil, 0, 0)
+      assert_equal 'unknown', AppOpticsAPM::Span.createSpan(nil, nil, 0, 0)
+      assert_equal 'unknown', AppOpticsAPM::Span.createSpan('', nil, 0, 0)
+      assert_equal 'domain/my_name', AppOpticsAPM::Span.createSpan('my_name', 'domain', 0, 0)
     end
   end
 end


### PR DESCRIPTION
2 things addressed in this PR:

1) Extra argument for createSpan
This PR only makes sure the we can run the code, it does not deal with actually indicating whether or not there is an error. A jira has been created for that: https://swicloud.atlassian.net/browse/AO-18902

2) Rename `Ruby.clib.Version` to `Ruby.AppOpticsExtension.Version` for cross-agent compitibility