### PR TITLE
AO 18477 partial renderer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - DBTYPE=mysql2
 
 rvm:
-#  - 3.0.0 # appoptics_apm instrumentation not ready yet
+  - 3.0.0 # appoptics_apm instrumentation not ready yet, probably ok, let's see
   - 2.7.0
   - 2.6.5
   - 2.5.5
@@ -24,6 +24,7 @@ gemfile:
   - gemfiles/instrumentation_mocked.gemfile
   - gemfiles/instrumentation_mocked_oldgems.gemfile
   - gemfiles/frameworks.gemfile
+  - gemfiles/rails61.gemfile
   - gemfiles/rails60.gemfile
   - gemfiles/rails52.gemfile
   - gemfiles/rails42.gemfile
@@ -38,6 +39,8 @@ matrix:
       gemfile: gemfiles/rails42.gemfile
     - rvm: 2.6.5
       gemfile: gemfiles/rails42.gemfile
+    - rvm: 2.4.5
+      gemfile: gemfiles/rails61.gemfile
     - rvm: 2.4.5
       gemfile: gemfiles/rails60.gemfile
     - rvm: 2.4.5  # excluding because of new sprockets version (4.0.0)

--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -8,8 +8,8 @@ gem 'rest-client'
 
 # doesn't install well on alpine, explained here:
 # https://qiita.com/takkeybook/items/5eae085d902957f0fe5b
-# TODO keep an eye out for new grpc > 1.27.0 for ruby 2.7
-if  !File.exist?('/etc/alpine-release') # && RUBY_VERSION < '2.7.0'
+# TODO keep an eye out for new grpc > 1.36.0 for ruby 3.0
+if  !File.exist?('/etc/alpine-release') && RUBY_VERSION < '3.0.0'
   gem 'grpc'
   gem 'google-protobuf'
 end

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -1,0 +1,38 @@
+source "https://rubygems.org"
+
+gem 'rails', '~> 6.1.0'
+gem 'sass-rails'
+gem 'uglifier'
+gem 'coffee-rails'
+gem 'therubyracer', platforms: :ruby
+gem 'jquery-rails'
+gem 'turbolinks'
+gem 'jbuilder'
+gem 'sidekiq'
+gem 'lograge'
+gem 'wicked_pdf'
+gem 'wkhtmltopdf-binary'
+
+group :development do
+  # Access an IRB console on exception pages or by using <%= console %> in views
+  gem 'web-console'
+  gem 'listen'
+  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'spring'
+  gem 'spring-watcher-listen'
+end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+if defined?(JRUBY_VERSION)
+  gem 'activerecord-jdbc-adapter'
+  gem 'jdbc-postgresql'
+else
+  gem 'pg'
+  gem 'mysql2'
+end
+
+eval(File.read(File.join(File.dirname(__FILE__), 'test_gems.gemfile')))
+gemspec :path => File.expand_path(File.dirname(__FILE__) + '/../')
+# vim:syntax=ruby

--- a/lib/appoptics_apm/frameworks/rails/inst/action_view.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/action_view.rb
@@ -6,35 +6,78 @@ if defined?(ActionView::Base) && AppOpticsAPM::Config[:action_view][:enabled]
   if Rails::VERSION::MAJOR >= 4
 
     AppOpticsAPM.logger.info '[appoptics_apm/loading] Instrumenting actionview' if AppOpticsAPM::Config[:verbose]
+    if ActionView.version >= Gem::Version.new('6.1.0') # the methods changed in this version
 
-    ActionView::PartialRenderer.class_eval do
-      alias :render_partial_without_appoptics :render_partial
-      def render_partial(*args)
-        entry_kvs = {}
-        begin
-          entry_kvs[:Partial] = AppOpticsAPM::Util.prettify(@options[:partial]) if @options.is_a?(Hash)
-        rescue => e
-          AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
-        end
+      ActionView::PartialRenderer.class_eval do
+        alias :render_partial_template_without_appoptics :render_partial_template
 
-        AppOpticsAPM::SDK.trace('partial', entry_kvs) do
-          entry_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:action_view][:collect_backtraces]
-          render_partial_without_appoptics(*args)
+        def render_partial_template(*args)
+          _, _, template, _, _ = args
+          entry_kvs = {}
+          begin
+            entry_kvs[:Partial] = template.virtual_path
+          rescue => e
+            AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
+          end
+          AppOpticsAPM::SDK.trace(:partial, entry_kvs) do
+            entry_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:action_view][:collect_backtraces]
+            render_partial_template_without_appoptics(*args)
+          end
         end
       end
 
-      alias :render_collection_without_appoptics :render_collection
-      def render_collection(*args)
-        entry_kvs = {}
-        begin
-          entry_kvs[:Partial] = AppOpticsAPM::Util.prettify(@path)
-        rescue => e
-          AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
+      ActionView::CollectionRenderer.class_eval do
+        alias :render_collection_without_appoptics :render_collection
+
+        def render_collection(*args)
+          _, _, _, template, _, _ = args
+          entry_kvs = {}
+          begin
+            entry_kvs[:Partial] = template.virtual_path
+          rescue => e
+            AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
+          end
+          AppOpticsAPM::SDK.trace(:collection, entry_kvs) do
+            entry_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:action_view][:collect_backtraces]
+            render_collection_without_appoptics(*args)
+          end
+        end
+      end
+
+    else # Rails < 6.1.0
+
+      ActionView::PartialRenderer.class_eval do
+        alias :render_partial_without_appoptics :render_partial
+        def render_partial(*args)
+          template = @template || args[1]
+          entry_kvs = {}
+          begin
+            entry_kvs[:Partial] = template.virtual_path
+            # entry_kvs[:Partial] = AppOpticsAPM::Util.prettify(@options[:partial]) if @options.is_a?(Hash)
+          rescue => e
+            AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
+          end
+
+          AppOpticsAPM::SDK.trace('partial', entry_kvs) do
+            entry_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:action_view][:collect_backtraces]
+            render_partial_without_appoptics(*args)
+          end
         end
 
-        AppOpticsAPM::SDK.trace('collection', entry_kvs) do
-          entry_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:action_view][:collect_backtraces]
-          render_collection_without_appoptics(*args)
+        alias :render_collection_without_appoptics :render_collection
+        def render_collection(*args)
+          template = @template || args[1]
+          entry_kvs = {}
+          begin
+            entry_kvs[:Partial] = template.virtual_path
+          rescue => e
+            AppOpticsAPM.logger.debug "[appoptics_apm/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if AppOpticsAPM::Config[:verbose]
+          end
+
+          AppOpticsAPM::SDK.trace('collection', entry_kvs) do
+            entry_kvs[:Backtrace] = AppOpticsAPM::API.backtrace if AppOpticsAPM::Config[:action_view][:collect_backtraces]
+            render_collection_without_appoptics(*args)
+          end
         end
       end
 

--- a/lib/appoptics_apm/util.rb
+++ b/lib/appoptics_apm/util.rb
@@ -273,6 +273,7 @@ module AppOpticsAPM
           platform_info['Ruby.Version']                 = RUBY_VERSION
           platform_info['Ruby.AppOptics.Version']       = AppOpticsAPM::Version::STRING
 
+          # oboe not loaded yet, can't use oboe_api function to read oboe VERSION
           clib_version_file = File.join(Gem::Specification.find_by_name('appoptics_apm').gem_dir, 'ext', 'oboe_metal', 'src', 'VERSION')
           platform_info['Ruby.AppOpticsExtension.Version'] = File.read(clib_version_file).chomp
           platform_info['RubyHeroku.AppOpticsAPM.Version'] = AppOpticsAPMHeroku::Version::STRING if defined?(AppOpticsAPMHeroku)

--- a/test/frameworks/rails4x_test.rb
+++ b/test/frameworks/rails4x_test.rb
@@ -43,7 +43,7 @@ if defined?(::Rails)
 
       _(traces[3]['Layer']).must_equal "partial"
       _(traces[3]['Label']).must_equal "entry"
-      _(traces[3]['Partial']).must_equal "somepartial"
+      _(traces[3]['Partial']).must_equal "hello/_somepartial"
       _(traces[4]['Layer']).must_equal "partial"
       _(traces[4]['Label']).must_equal "exit"
     end
@@ -58,7 +58,7 @@ if defined?(::Rails)
 
       _(traces[11]['Layer']).must_equal "collection"
       _(traces[11]['Label']).must_equal "entry"
-      _(traces[11]['Partial']).must_equal "widget"
+      _(traces[11]['Partial']).must_equal "hello/_widget"
       _(traces[12]['Layer']).must_equal "collection"
       _(traces[12]['Label']).must_equal "exit"
     end

--- a/test/frameworks/rails5x_api_test.rb
+++ b/test/frameworks/rails5x_api_test.rb
@@ -37,7 +37,7 @@ if defined?(::Rails)
 
       _(traces[3]['Layer']).must_equal "partial"
       _(traces[3]['Label']).must_equal "entry"
-      _(traces[3]['Partial']).must_equal "somepartial"
+      _(traces[3]['Partial']).must_equal "hello/_somepartial"
       _(traces[4]['Layer']).must_equal "partial"
       _(traces[4]['Label']).must_equal "exit"
     end
@@ -52,7 +52,7 @@ if defined?(::Rails)
 
       _(traces[11]['Layer']).must_equal "collection"
       _(traces[11]['Label']).must_equal "entry"
-      _(traces[11]['Partial']).must_equal "widget"
+      _(traces[11]['Partial']).must_equal "hello/_widget"
       _(traces[12]['Layer']).must_equal "collection"
       _(traces[12]['Label']).must_equal "exit"
     end

--- a/test/frameworks/rails5x_test.rb
+++ b/test/frameworks/rails5x_test.rb
@@ -45,7 +45,7 @@ if defined?(::Rails)
 
       _(traces[3]['Layer']).must_equal "partial"
       _(traces[3]['Label']).must_equal "entry"
-      _(traces[3]['Partial']).must_equal "somepartial"
+      _(traces[3]['Partial']).must_equal "hello/_somepartial"
       _(traces[4]['Layer']).must_equal "partial"
       _(traces[4]['Label']).must_equal "exit"
     end
@@ -60,7 +60,7 @@ if defined?(::Rails)
 
       _(traces[11]['Layer']).must_equal "collection"
       _(traces[11]['Label']).must_equal "entry"
-      _(traces[11]['Partial']).must_equal "widget"
+      _(traces[11]['Partial']).must_equal "hello/_widget"
       _(traces[12]['Layer']).must_equal "collection"
       _(traces[12]['Label']).must_equal "exit"
     end

--- a/test/run_tests/run_matrix.sh
+++ b/test/run_tests/run_matrix.sh
@@ -23,7 +23,7 @@ group :development, :test do
   gem 'rake'
   gem 'puma' # , '< 3.1.0'
   gem 'webmock'
-  gem 'grpc-tools' if RUBY_VERSION < '2.7.0'
+  gem 'grpc-tools' if RUBY_VERSION < '3.0.0'
 end
 EOM
 

--- a/test/servers/rackapp_8101.rb
+++ b/test/servers/rackapp_8101.rb
@@ -21,7 +21,7 @@ Thread.new do
     end
   }
 
-  Rack::Handler::Puma.run(app, {:Host => '127.0.0.1', :Port => 8101})
+  Rack::Handler::Puma.run(app, :Host => '127.0.0.1', :Port => 8101)
 end
 
 AppOpticsAPM.logger.info "[appoptics_apm/info] Starting UNINSTRUMENTED background utility rack app on localhost:8110."
@@ -37,7 +37,7 @@ Thread.new do
     end
   }
 
-  Rack::Handler::Puma.run(app, {:Host => '127.0.0.1', :Port => 8110})
+  Rack::Handler::Puma.run(app, :Host => '127.0.0.1', :Port => 8110)
 end
 
 # Allow Thin to boot.

--- a/test/servers/rails5x_8140.rb
+++ b/test/servers/rails5x_8140.rb
@@ -194,7 +194,7 @@ AppOpticsAPM::SDK.trace_method(FerroController, :world)
 Rails50MetalStack.initialize!
 
 Thread.new do
-  Rack::Handler::Puma.run(Rails50MetalStack.to_app, {:Host => '127.0.0.1', :Port => 8140})
+  Rack::Handler::Puma.run(Rails50MetalStack.to_app, :Host => '127.0.0.1', :Port => 8140)
 end
 
 sleep(2)

--- a/test/servers/rails5x_api_8150.rb
+++ b/test/servers/rails5x_api_8150.rb
@@ -5,16 +5,6 @@
 #  This is a Rails API stack that launches on a background
 #  thread and listens on port 8150.
 #
-if ENV['DBTYPE'] == 'mysql2'
-  AppOpticsAPM::Test.set_mysql2_env
-elsif ENV['DBTYPE'] =~ /postgres/
-  AppOpticsAPM::Test.set_postgresql_env
-else
-  AppOpticsAPM.logger.warn "[appoptics_apm/rails] Unidentified DBTYPE: #{ENV['DBTYPE']}"
-  AppOpticsAPM.logger.debug "[appoptics_apm/rails] Defaulting to postgres DB for background Rails server."
-  AppOpticsAPM::Test.set_postgresql_env
-end
-
 require "rails"
 require "active_model/railtie"
 require "active_job/railtie"
@@ -26,6 +16,17 @@ require "action_cable/engine"
 require "rails/test_unit/railtie"
 
 require 'rack/handler/puma'
+
+if ENV['DBTYPE'] == 'mysql2'
+  AppOpticsAPM::Test.set_mysql2_env
+elsif ENV['DBTYPE'] =~ /postgres/
+  AppOpticsAPM::Test.set_postgresql_env
+else
+  AppOpticsAPM.logger.warn "[appoptics_apm/rails] Unidentified DBTYPE: #{ENV['DBTYPE']}"
+  AppOpticsAPM.logger.debug "[appoptics_apm/rails] Defaulting to postgres DB for background Rails server."
+  AppOpticsAPM::Test.set_postgresql_env
+end
+
 require File.expand_path(File.dirname(__FILE__) + '/../models/widget')
 
 AppOpticsAPM.logger.info "[appoptics_apm/info] Starting background utility rails app on localhost:8150."
@@ -73,7 +74,7 @@ end
 Rails50APIStack::Application.initialize!
 
 Thread.new do
-  Rack::Handler::Puma.run(Rails50APIStack::Application.to_app, {:Host => '127.0.0.1', :Port => 8150})
+  Rack::Handler::Puma.run(Rails50APIStack::Application.to_app, :Host => '127.0.0.1', :Port => 8150)
 end
 
 sleep(2)

--- a/test/support/init_report_test.rb
+++ b/test/support/init_report_test.rb
@@ -15,7 +15,7 @@ describe 'InitReportTest' do
     _(init_kvs.has_key?("Force")).must_equal true
     _(init_kvs.has_key?("Ruby.AppContainer.Version")).must_equal true
     _(init_kvs["Ruby.AppOptics.Version"]).must_equal AppOpticsAPM::Version::STRING
-    _(init_kvs["Ruby.AppOpticsExtension.Version"]).must_equal File.read(clib_version_file).chomp
+    _(init_kvs["Ruby.AppOpticsExtension.Version"]).must_equal Oboe_metal::Config.getVersionString
     _(init_kvs["Ruby.TraceMode.Version"]).must_equal AppOpticsAPM::Config[:tracing_mode]
   end
 


### PR DESCRIPTION
this is going to be the first release in 4 months, therefore there is a bit of cleanup in this PR as well

Main issue:
- New instrumentation for PartialRenderer and CollectionRenderer for Rails >= 6.1, the value strings now include the model and the template (makes it easier to find the culprit if it is slow)

Further Fixes:
- include and support Ruby 3.0.0 (needed small fix in the params of the test servers)
- add a copy option for running tests, so the run with a copy of the code and not the code worked on
- use `Oboe_metal::Config.getVersionString` to test kv in init report
