### PR TITLE
A0-20359 adapt to changes in redis gem 4.4.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,14 +51,15 @@ Rake::TestTask.new do |t|
   when /libraries/
     t.test_files = FileList['test/support/*_test.rb'] +
                    FileList['test/reporter/*_test.rb'] +
-                   FileList['test/instrumentation/*_test.rb'] +
-                   FileList['test/profiling/*_test.rb'] -
+                   FileList['test/instrumentation/*_test.rb'] -
                    ['test/instrumentation/twitter-cassandra_test.rb']
   when /instrumentation_mocked/
     # WebMock is interfering with other tests, so these have to run separately
     t.test_files = FileList['test/mocked/*_test.rb']
   when /noop/
     t.test_files = FileList['test/noop/*_test.rb']
+  when /profiling/
+    t.test_files = FileList['test/profiling/*_test.rb']
   when /unit/
     t.test_files = FileList['test/unit/*_test.rb'] +
                    FileList['test/unit/*/*_test.rb']
@@ -76,7 +77,7 @@ task :docker_tests, :environment do
   os = arg2 || 'ubuntu'
 
   Dir.chdir('test/run_tests')
-  exec("docker-compose down -v --remove-orphans && docker-compose run --service-ports --name ruby_appoptics_#{os} ruby_appoptics_#{os} /code/ruby-appoptics/test/run_tests/ruby_setup.sh test")
+  exec("docker-compose down -v --remove-orphans && docker-compose run --service-ports --name ruby_appoptics_#{os} ruby_appoptics_#{os} /code/ruby-appoptics/test/run_tests/ruby_setup.sh test copy")
 end
 
 task :docker_test => :docker_tests

--- a/examples/sdk_examples.rb
+++ b/examples/sdk_examples.rb
@@ -140,3 +140,19 @@ AppOpticsAPM::SDK.start_trace('log_trace_id') do
   trace = AppOpticsAPM::SDK.current_trace
   AppOpticsAPM.logger.warn "Some log message #{trace.for_log}"
 end
+
+###############################################################
+# START A TRACE AND PROFILE
+###############################################################
+#
+# AppOpticsAPM::Profiling.run
+# This method adds profiling for the code executed in the block
+
+AppOpticsAPM::SDK.start_trace("#{name}_profiling") do
+  AppOpticsAPM::Profiling.run do
+    10.times do
+      [9, 6, 12, 2, 7, 1, 9, 3, 4, 14, 5, 8].sort
+      sleep 0.2
+    end
+  end
+end

--- a/gemfiles/profiling.gemfile
+++ b/gemfiles/profiling.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+eval(File.read(File.join(File.dirname(__FILE__), 'test_gems.gemfile')))
+gemspec :path => File.expand_path(File.dirname(__FILE__) + '/../')

--- a/lib/appoptics_apm/config.rb
+++ b/lib/appoptics_apm/config.rb
@@ -225,9 +225,12 @@ module AppOpticsAPM
         end
 
       elsif key == :profiling_interval
-        unless value.is_a?(Integer) && value > 0
-          @@config[:profiling_interval] = 10
+        if value.is_a?(Integer) && value > 0
+          value = [100, value].min
+        else
+          value = 10
         end
+        @@config[:profiling_interval] = value
         # CProfiler may not be loaded yet, the profiler will send the value
         # after it is loaded
         AppOpticsAPM::CProfiler.set_interval(value) if defined? AppOpticsAPM::CProfiler
@@ -269,8 +272,6 @@ module AppOpticsAPM
       end
     end
     # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
-
-
 
     def self.method_missing(sym, *args)
       class_var_name = "@@#{sym}"

--- a/lib/appoptics_apm/inst/redis.rb
+++ b/lib/appoptics_apm/inst/redis.rb
@@ -76,8 +76,7 @@ module AppOpticsAPM
 
           kvs[:KVOp] = command[0]
           kvs[:RemoteHost] = @options[:host]
-
-          unless NO_KEY_OPS.include?(op) || (command[1].is_a?(Array) && command[1].count > 1)
+          unless NO_KEY_OPS.include?(op) || op == :del && command[1..-1].flatten.count > 1
             if command[1].is_a?(Array)
               kvs[:KVKey] = command[1].first
             else

--- a/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
+++ b/lib/rails/generators/appoptics_apm/templates/appoptics_apm_initializer.rb
@@ -96,6 +96,8 @@ if defined?(AppOpticsAPM::Config)
   # The default is 10 milliseconds, which means that the method call stack is
   # recorded every 10 milliseconds. Shorter intervals may give better insight,
   # but will incur more overhead.
+  # Minimum: 1, Maximum: 100
+  #
   AppOpticsAPM::Config[:profiling_interval] = 10
 
   #

--- a/test/instrumentation/rack_transaction_name_test.rb
+++ b/test/instrumentation/rack_transaction_name_test.rb
@@ -71,7 +71,7 @@ describe AppOpticsAPM::SDK do
 
     Time.stub(:now, Time.at(0)) do
       AppOpticsAPM::Span.expects(:createHttpSpan).with(name, url, nil, 0, 200, 'GET', 0).returns(name)
-      AppOpticsAPM::API.expects(:log_exit).with(:rack, :Status => 200, :TransactionName => name)
+      AppOpticsAPM::API.expects(:log_exit).with(:rack, :Status => 200, :TransactionName => name, :ProfileSpans => -1)
 
       get "/#{name}"
 
@@ -87,7 +87,7 @@ describe AppOpticsAPM::SDK do
 
     Time.stub(:now, Time.at(0)) do
       AppOpticsAPM::Span.expects(:createHttpSpan).with(nil, url, nil, 0, 200, 'GET', 0).returns("c.a")
-      AppOpticsAPM::API.expects(:log_exit).with(:rack, :Status => 200, :TransactionName => "c.a")
+      AppOpticsAPM::API.expects(:log_exit).with(:rack, :Status => 200, :TransactionName => "c.a", :ProfileSpans => -1)
 
       get "/#{name}"
     end
@@ -99,7 +99,7 @@ describe AppOpticsAPM::SDK do
 
     Time.stub(:now, Time.at(0)) do
       AppOpticsAPM::Span.expects(:createHttpSpan).with(name, url, nil, 0, 200, 'GET', 0).returns("other")
-      AppOpticsAPM::API.expects(:log_exit).with(:rack, :Status => 200, :TransactionName => "other")
+      AppOpticsAPM::API.expects(:log_exit).with(:rack, :Status => 200, :TransactionName => "other", :ProfileSpans => -1)
 
       get "/#{name}"
     end
@@ -127,7 +127,7 @@ describe AppOpticsAPM::SDK do
     AppOpticsAPM::API.set_transaction_name("another_name")
     Time.stub(:now, Time.at(0)) do
       AppOpticsAPM::Span.expects(:createHttpSpan).with(name, url, nil, 0, 200, 'GET', 0).returns(name)
-      AppOpticsAPM::API.expects(:log_exit).with(:rack, :Status => 200, :TransactionName => name)
+      AppOpticsAPM::API.expects(:log_exit).with(:rack, :Status => 200, :TransactionName => name, :ProfileSpans => -1)
 
       get "/#{name}"
     end

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -395,4 +395,32 @@ describe "AppOpticsAPM::Config" do
     AppOpticsAPM::Config.expects(:load).with(@test_config_path).times(1)
     AppOpticsAPM::Config.load_config_file
   end
+
+  describe "profiling_interval configuration" do
+    before do
+      AppOpticsAPM::Config.load_config_file
+    end
+
+    it 'accepts the minimum value of 1' do
+      AppOpticsAPM::Config['profiling_interval'] = 1
+      _(AppOpticsAPM::Config.profiling_interval).must_equal 1
+    end
+
+    it 'accepts the maximum value of 100' do
+      AppOpticsAPM::Config['profiling_interval'] = 100
+      _(AppOpticsAPM::Config.profiling_interval).must_equal 100
+    end
+
+    it 'sets the default of 10 for invalid entries' do
+      AppOpticsAPM::Config['profiling_interval'] = -1
+
+      _(AppOpticsAPM::Config.profiling_interval).must_equal 10
+    end
+
+    it 'sets the maximum of 100 for values > 100' do
+      AppOpticsAPM::Config['profiling_interval'] = 1000000000000000000000000000000
+
+      _(AppOpticsAPM::Config.profiling_interval).must_equal 100
+    end
+  end
 end


### PR DESCRIPTION
- the arguments to :del get flattend, condition needs to change
- `exists` will switch to returning an int, `exists?` should be used when a boolean is expected

A0-20359