### PR TITLE
Dalli gem version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ ext/oboe_metal/src/oboe.h
 ext/oboe_metal/src/oboe_api.hpp
 ext/oboe_metal/src/oboe_debug.h
 ext/oboe_metal/src/oboe_swig_wrap.cc
+/ext/oboe_metal/src/VERSION_latest
 ext/oboe_metal/test/build/
 ext/oboe_metal/test/MakeFile
 gemfiles/*.lock

--- a/gemfiles/frameworks.gemfile
+++ b/gemfiles/frameworks.gemfile
@@ -1,6 +1,12 @@
 source "https://rubygems.org"
 
-gem 'dalli'
+
+if RUBY_VERSION < '2.5'
+  gem 'dalli', '< 3.0.0'
+else
+  gem 'dalli'
+end
+
 gem 'grape'
 gem 'rack' # , '~> 2.0.8'
 

--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -17,7 +17,13 @@ end
 gem 'bunny'
 # gem 'cassandra'
 gem 'curb'
-gem 'dalli'
+
+if RUBY_VERSION < '2.5'
+  gem 'dalli', '< 3.0.0'
+else
+  gem 'dalli'
+end
+
 gem 'excon'
 gem 'faraday'
 gem 'graphql', '~> 1.11.7' #, :path => "/code/graphql-ruby" # keep for local testing/debugging

--- a/test/instrumentation/rack_test.rb
+++ b/test/instrumentation/rack_test.rb
@@ -168,6 +168,10 @@ describe "Rack: " do
     AppOpticsAPM::Config[:profiling] = @profiling
   end
 
+  after(:all) do
+    WebMock.disable!
+  end
+
   # A and B implement the acceptance tests as outlined in the google doc
   describe 'A - tracing mode :enabled' do
     before do

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -22,6 +22,7 @@ require 'minitest/reporters'
 require 'minitest'
 require 'minitest/focus'
 require 'minitest/debugger' if ENV['DEBUG']
+require 'minitest/hooks/default'  # adds after(:all)
 
 
 # write to a file as well as STDOUT (comes in handy with docker runs)


### PR DESCRIPTION
This PR addresses 2 issues

dalli version >= 3 doesn't work with Ruby 2.4
disabling WebMock after Rack tests should make the test suite less brittle